### PR TITLE
docs: fix typos

### DIFF
--- a/docs/tributors.md
+++ b/docs/tributors.md
@@ -2,7 +2,7 @@
 
 You can save a single metadata file in your repository that includes common fields
 to use to update other metadata files. As an example, here we see a file generated
-after an intial run - we index by the GitHub username since on GitHub that is our
+after an initial run - we index by the GitHub username since on GitHub that is our
 "unit of truth." These are a few entries for Singularity Registry Server:
 
 ```bash

--- a/tributors/main/parsers/allcontrib.py
+++ b/tributors/main/parsers/allcontrib.py
@@ -89,7 +89,7 @@ class AllContribParser(ParserBase):
         bot.info(f"Generating {filename} for {repo}")
         owner, repo = repo.split("/")[:2]
 
-        # Write metadata to empty all contributors flie.
+        # Write metadata to empty all contributors file.
         metadata = {
             "projectName": repo,
             "projectOwner": owner,


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `docs/tributors.md`
- 1 typo in `tributors/main/parsers/allcontrib.py`



Ciao! :robot: