### PR TITLE
adding auto detect feature for existing files

### DIFF
--- a/.tributors
+++ b/.tributors
@@ -7,7 +7,9 @@
     "yarikoptic": {
         "name": "Yaroslav Halchenko",
         "bio": "Cheers!",
-        "blog": "www.onerussian.com"
+        "blog": "www.onerussian.com",
+        "orcid": "0000-0003-3456-2493",
+        "affiliation": "Dartmouth College"
     },
     "pgrimaud": {
         "name": "Pierre Grimaud",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # tributors
 
-![docs/assets/img/logo.png](docs/assets/img/logo.png)
+![docs/assets/img/logo.png](https://raw.githubusercontent.com/con/tributors/master/docs/assets/img/logo.png)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+[Documentation](https://con.github.io/tributors/)
 
 ## What is tributors?
 
@@ -13,7 +15,7 @@ contributors. Tribute interacts with several well-known repository metadata file
 
  - [all-contributors](https://github.com/all-contributors)
  - [Zenodo](https://zenodo.org)
- - [CodeMeta](https://codemeta.github.io/) **under development**
+ - [CodeMeta](https://codemeta.github.io/)
 
 Each of the services above allows you to generate some kind of metadata file
 that has one or more repository contributors. This file typically needs to be
@@ -27,48 +29,11 @@ or use an interactive mode to make decisions as you go.
 
 ## How does it work?
 
-Tributors uses the following sources of information to update your contributor
-files.
+Tributors uses the GitHub API, Zenodo API, and Orcid API to look up shared identifiers
+for common metadata services like all contributors, Zenodo, and CodeMeta. The
+tool is available for local or container usage, and as a GitHub Action (see the [examples](examples) folder).
+See the full [documentation](https://con.github.io/tributors/) for getting started.
 
-### GitHub API
-
-Since these files are served in GitHub repositories, it's fairly easy to
-retrieve repository contributors using the GitHub API in both cases.
-
-### Orcid
-
-Given that you provide an Orcid token and secret to request API tokens, we can find [Orcid records](https://members.orcid.org/api/tutorial/read-orcid-records) based on email addresses.
-
-### Zenodo
-
-Zenodo also has a [rest API](https://developers.zenodo.org/) that can be used to create an initial `.zenodo.json` for a repository. 
-
-The GitHub Action details are included below. See the [docs](docs) for more detailed
-usage, both on your local machine, and via a Docker container.
-
-## GitHub Action
-
-Since [all-contributors](https://github.com/all-contributors) requires node,
-you might find it easiest to interact with the tool via a GitHub action.
-You can see examples in the [examples](examples) folder.
-
-#### Inputs
-
-| name | description | required | default |
-|------|-------------|----------|---------|
-| parsers | a space separated list of parsers (e.g., "zenodo allcontrib") or just "all" | false | all | 
-| zenodo_file | .zenodo.json to update. If does not exist, must define zenodo_doi | false | .zenodo.json | 
-| zenodo_doi | Zenodo DOI needed for init. Leave unset to skip init. | false | unset | 
-| log_level | Log level to use, one of INFO, DEBUG, CRITICAL, ERROR, WARNING, FATAL (default INFO) | false | INFO | 
-| threshold | the minimum number of contributions required to add a user | false | 1 | 
-| force | if files exist, force overwrit | false | false |
-| allcontrib_file |The all contributors file | false | .all-contributorsrc |
-| allcontrib_type |Contribution type, which defaults to "code" if not set. | false | code |
-| allcontrib_skip_generate | skip running all-contributors generate | false | false |
-
-If you aren't familiar with all-contributors, you'll need to add some
-[commenting in your repository README](https://allcontributors.org/docs/en/cli/usage)
-so the client knows where to write.
 
 ## Contributors
 
@@ -86,8 +51,3 @@ so the client knows where to write.
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-
-
-## @vsoch TODO
-
- - an example should be added to push to a repository / open PR

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -12,6 +12,39 @@ description: Getting started with tributors
 This guide will provide getting started instructions for local and Docker Usage,
 along with GitHub Workflows.
 
+## Quick Start
+
+Install tributors
+
+```bash
+pip install tributors
+```
+
+If you have a repository with files already defined, you can use the auto-detect
+update (not specifying a particular contributor parser):
+
+```bash
+$ tributors update
+```
+
+or update a specific one:
+
+```bash
+$ tributors update allcontrib
+$ tributors update zenodo
+$ tributors update codemeta
+```
+
+You can also create empty files if you don't have them yet:
+
+```bash
+$ tributors init allcontrib
+$ tributors init zenodo
+```
+
+You can read more about the various [parsers]({{ site.baseurl }}/docs/parsers)
+for specific-parser arguments.
+
 ## Docker Usage
 
 If you don't want to use the GitHub Action and don't want to install npm on
@@ -153,16 +186,19 @@ and do the following:
 $ tributors update all
 ```
 
-"all" is the default, so this works too:
+#### Update (auto)
+
+If you have a repository with one or more default contributor files, you can
+update all of these files that are detected by leaving out the parser name:
 
 ```bash
 $ tributors update
 INFO:zenodo:Updating .zenodo.json
 INFO:allcontrib:Updating .all-contributorsrc
 ```
-Note that for the update, we query the GitHub API to update both the zenodo.json
-and contributors file. We also use a cached [.tributors]({{ site.baseurl }}/docs/tributors) file to
-keep track of shared contributors.
+Note that for any multiple updates, we query the GitHub API to get updated contributors,
+and also use a cached [.tributors]({{ site.baseurl }}/docs/tributors) file to
+keep track of shared metadata.
 
 #### Update allcontributors
 
@@ -386,7 +422,10 @@ INFO:zenodo:Updating .zenodo.json
 INFO:allcontrib:Updating .all-contributorsrc
 ```
 
-or just 
+#### Update (auto)
+
+If you have a repository with one or more default contributor files, you can
+update all of these files that are detected by leaving out the parser name:
 
 ```bash
 $ tributors update

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -14,12 +14,34 @@ along with GitHub Workflows.
 
 ## Quick Start
 
+### 1. Install
 Install tributors
 
 ```bash
 pip install tributors
 ```
 
+### 2. Environment
+
+Especially if you need orcid ids in your metadata, for a first time go you
+should export an id and secret to interact with the Orcid API. It'a also recommended
+to export a GitHub token to increase your API limit:
+
+```bash
+export ORCID_ID=APP-XXXXXXX
+export ORCID_SECRET=12345678910111213141516171819202122
+export GITHUB_TOKEN=XXXXXXXXXXXXXXX
+```
+
+Once you generate an orcid token, it will be written to a temporary file,
+and you can read the file and export the variable for later discovery (and you'll
+no longer need the ID and secret):
+
+```bash
+export ORCID_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+### 3. Update
 If you have a repository with files already defined, you can use the auto-detect
 update (not specifying a particular contributor parser):
 
@@ -35,6 +57,7 @@ $ tributors update zenodo
 $ tributors update codemeta
 ```
 
+### 3. Init
 You can also create empty files if you don't have them yet:
 
 ```bash
@@ -43,7 +66,8 @@ $ tributors init zenodo
 ```
 
 You can read more about the various [parsers]({{ site.baseurl }}/docs/parsers)
-for specific-parser arguments.
+for specific-parser arguments, and more details about the above commands in the
+sections below.
 
 ## Docker Usage
 

--- a/docs/_docs/parsers/allcontrib.md
+++ b/docs/_docs/parsers/allcontrib.md
@@ -87,6 +87,10 @@ files) that you want rendered.
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 ```
 
+Read more about this
+[commenting in your repository README](https://allcontributors.org/docs/en/cli/usage)
+so the client knows where to write. 
+
 ### The .tributors file
 
 After you run this command, you'll also notice you have a `.tributors` file

--- a/tributors/client/__init__.py
+++ b/tributors/client/__init__.py
@@ -82,8 +82,8 @@ def get_parser():
             "parsers",
             help="Metadata file parsers to update or initialize.",
             nargs="*",
-            default="all",
-            choices=["zenodo", "allcontrib", "codemeta", "all"],
+            default="unset",
+            choices=["zenodo", "allcontrib", "codemeta", "all", "unset"],
         )
         command.add_argument(
             "--repo", help="The repository URI, if not exported to GITHUB_REPOSITORY",

--- a/tributors/client/init.py
+++ b/tributors/client/init.py
@@ -38,6 +38,4 @@ def main(args, extra):
 
     else:
         parsers = [x for x in args.parsers if x != "unset"]
-        client.init(
-            parsers=parsers, repo=args.repo, params=extra, force=args.force
-        )
+        client.init(parsers=parsers, repo=args.repo, params=extra, force=args.force)

--- a/tributors/client/init.py
+++ b/tributors/client/init.py
@@ -10,6 +10,10 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from tributors.main import TributorsClient
 from .utils import parse_extra
+import logging
+import sys
+
+bot = logging.getLogger("github")
 
 
 def main(args, extra):
@@ -18,6 +22,11 @@ def main(args, extra):
 
     # Parse extra arguments
     extra = parse_extra(extra)
+
+    # Tell the user to init a particular parser
+    if "unset" in args.parsers:
+        bot.info("Please specify one or more parsers, one of zenodo, codemeta")
+        sys.exit(0)
 
     if "all" in args.parsers:
         client.init(
@@ -28,6 +37,7 @@ def main(args, extra):
         )
 
     else:
+        parsers = [x for x in args.parsers if x != "unset"]
         client.init(
-            parsers=args.parsers, repo=args.repo, params=extra, force=args.force
+            parsers=parsers, repo=args.repo, params=extra, force=args.force
         )

--- a/tributors/client/update.py
+++ b/tributors/client/update.py
@@ -10,6 +10,8 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from tributors.main import TributorsClient
 from .utils import parse_extra
+import os
+import sys
 
 
 def main(args, extra):
@@ -19,7 +21,27 @@ def main(args, extra):
     # Parse extra arguments
     extra = parse_extra(extra)
 
-    if "all" in args.parsers:
+    # Start with user provided parsers
+    parsers = args.parsers
+
+    # If unset, try to detect files
+    if "unset" in parsers:
+        lookup = {
+            "allcontrib": extra.get("--allcontrib-file", ".all-contributorsrc"),
+            "zenodo": extra.get("--zenodo-file", ".zenodo.json"),
+            "codemeta": extra.get("--codemeta-file", ".codemeta.json"),
+        }
+
+        parsers = []
+        for parser, filename in lookup.items():
+            if os.path.exists(filename):
+                parsers.append(parser)
+
+        # Exit if no parsers auto-detected
+        if not parsers:
+            sys.exit("No parsers auto-detected. Specify a parser name instead?")
+
+    if "all" in parsers:
         client.update(
             parsers=["zenodo", "allcontrib", "codemeta"],
             thresh=args.thresh,
@@ -28,6 +50,4 @@ def main(args, extra):
         )
 
     else:
-        client.update(
-            parsers=args.parsers, repo=args.repo, params=extra, thresh=args.thresh
-        )
+        client.update(parsers=parsers, repo=args.repo, params=extra, thresh=args.thresh)

--- a/tributors/main/github.py
+++ b/tributors/main/github.py
@@ -163,7 +163,7 @@ def get_github_repository(repo):
         # Issue running command
         if command.returncode != 0 or not command.out:
             sys.exit("Could not determine repository from local .git.")
-        repo = command.out[0]
+        repo = "/".join(command.out[0].strip().split("/")[-2:])
 
     match = re.search(repository_regex, repo)
 

--- a/tributors/main/parsers/allcontrib.py
+++ b/tributors/main/parsers/allcontrib.py
@@ -130,7 +130,7 @@ class AllContribParser(ParserBase):
         repo = "%s/%s" % (data["projectOwner"], data["projectName"])
         if repo != self.repo.uid:
             bot.warning(
-                "Found different repository in {filename}, updating from {self.repo.uid}"
+                f"Found different repository in {filename}, updating from {self.repo.uid}"
             )
             self._repo = GitHubRepository(repo)
 

--- a/tributors/main/parsers/allcontrib.py
+++ b/tributors/main/parsers/allcontrib.py
@@ -150,11 +150,19 @@ class AllContribParser(ParserBase):
                 entry = {
                     "login": login,
                     "name": cache.get("name") or login,
-                    "avatar_url": self.contributors.get(login, {}).get("avatar_url"),
-                    "profile": cache.get("blog")
-                    or self.contributors.get(login, {}).get("html_url"),
                     "contributions": [ctype],
                 }
+
+            # Only add profile and profile if not added yet
+            if "profile" not in entry:
+                entry["profile"] = cache.get("blog") or self.repo.contributors.get(
+                    login, {}
+                ).get("html_url")
+            if "avatar_url" not in entry:
+                entry["avatar_url"] = (
+                    self.repo.contributors.get(login, {}).get("avatar_url"),
+                )
+
             if ctype not in entry["contributions"]:
                 entry["contributions"].append(ctype)
             self.lookup[login] = entry

--- a/tributors/main/parsers/allcontrib.py
+++ b/tributors/main/parsers/allcontrib.py
@@ -128,15 +128,21 @@ class AllContribParser(ParserBase):
 
         # Sanity check that we have the correct repository
         repo = "%s/%s" % (data["projectOwner"], data["projectName"])
+
         if repo != self.repo.uid:
             bot.warning(
-                f"Found different repository in {filename}, updating from {self.repo.uid}"
+                f"Found different repository {repo} in {filename}, updating from {self.repo.uid}"
             )
             self._repo = GitHubRepository(repo)
 
         self.update_cache()
 
         for login, _ in self.repo.contributors.items():
+
+            # Check against contribution threshold, and not bot
+            if not self.include_contributor(login):
+                continue
+
             cache = self.cache.get(login) or {}
             if login in self.lookup:
                 entry = self.lookup[login]

--- a/tributors/main/parsers/base.py
+++ b/tributors/main/parsers/base.py
@@ -57,6 +57,21 @@ class ParserBase:
         """
         raise NotImplementedError
 
+    def include_contributor(self, login):
+        """Given a threshold (and preference to not include bots) return a boolean
+           to indicate including the contributor or not
+        """
+        contributor = self.repo.contributors.get(login)
+
+        # If they don't meet the threshold, continue
+        if contributor["contributions"] < self.thresh:
+            return False
+
+        # Skip GitHub bots
+        if contributor["type"] == "Bot" or "[bot]" in contributor["login"]:
+            return False
+        return True
+
     def update_cache(self):
         """A shared function to get updated GitHub contributors to update
            the local cache. This is where we parse all the data that we need 
@@ -64,14 +79,6 @@ class ParserBase:
            For users that have an email, we can attempt lookup with Orcid. 
         """
         for login, contributor in self.repo.contributors.items():
-
-            # If they don't meet the threshold, continue
-            if contributor["contributions"] < self.thresh:
-                continue
-
-            # Skip GitHub bots
-            if contributor["type"] == "Bot" or "[bot]" in contributor["login"]:
-                continue
 
             # Look up a GitHub username, possibly email and site
             user = get_user(login)

--- a/tributors/main/parsers/codemeta.py
+++ b/tributors/main/parsers/codemeta.py
@@ -97,6 +97,11 @@ class CodeMetaParser(ParserBase):
 
         # Now add contributors using cache (new GitHub contributors) with known email or orcid that isn't present
         for login, _ in self.repo.contributors.items():
+
+            # Check against contribution threshold, and not bot
+            if not self.include_contributor(login):
+                continue
+
             cache = self.cache.get(login) or {}
             email = cache.get("email")
             orcid = cache.get("orcid")

--- a/tributors/main/parsers/zenodo.py
+++ b/tributors/main/parsers/zenodo.py
@@ -50,6 +50,11 @@ class ZenodoParser(ParserBase):
         self.update_cache()
 
         for login, _ in self.repo.contributors.items():
+
+            # Check against contribution threshold, and not bot
+            if not self.include_contributor(login):
+                continue
+
             cache = self.cache.get(login) or {}
             entry = {"name": cache.get("name") or login}
             if "orcid" in cache:
@@ -92,6 +97,11 @@ class ZenodoParser(ParserBase):
         self.update_cache()
 
         for login, _ in self.repo.contributors.items():
+
+            # Check against contribution threshold, and not bot
+            if not self.include_contributor(login):
+                continue
+
             cache = self.cache.get(login) or {}
             entry = {"name": cache.get("name") or login}
             if login in self.cache:


### PR DESCRIPTION
Currently, update serves to default to "all," but this isn't great usage because it's unlikely that a repo will have all the files. Instead, we add an "unset" option that indicates not defined, and then auto-detect the files in the repository to derive the list.

This will close #22 

Signed-off-by: vsoch <vsochat@stanford.edu>