### PR TITLE
Add support for updating lookup

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -21,6 +21,9 @@ jobs:
           # Single text list (space separated) of parsers, or all (default)
           parsers: zenodo allcontrib
 
+          # One or more resources (and optional arguments) to update .tributors
+          update_lookup: "mailmap --mailmap-file tests/.mailmap"
+
           # INFO, DEBUG, ERROR, WARNING, etc.
           log_level: DEBUG
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -22,7 +22,7 @@ jobs:
           parsers: zenodo allcontrib
 
           # One or more resources (and optional arguments) to update .tributors
-          update_lookup: "mailmap --mailmap-file tests/.mailmap"
+          update_lookup: mailmap --mailmap-file tests/.mailmap
 
           # INFO, DEBUG, ERROR, WARNING, etc.
           log_level: DEBUG

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -22,7 +22,10 @@ jobs:
           parsers: zenodo allcontrib
 
           # One or more resources (and optional arguments) to update .tributors
-          update_lookup: mailmap --mailmap-file tests/.mailmap
+          update_lookup: mailmap 
+ 
+          # This file will be used for running update-lookup
+          mailmap_file: "tests/.mailmap"
 
           # INFO, DEBUG, ERROR, WARNING, etc.
           log_level: DEBUG

--- a/.tributors
+++ b/.tributors
@@ -16,5 +16,70 @@
         "name": "Pierre Grimaud",
         "blog": "https://github.com/pgrimaud",
         "bio": "Technical Manager @bigyouth / IT Teacher / Retired gladiator"
+    },
+    "tschoonj": {
+        "name": "Tom Schoonjans",
+        "bio": "I'm a research software engineer working @rosalindfranklininstitute, and am passionate about developing quality open source software.",
+        "blog": "tschoonj.github.io"
+    },
+    "Aneoshun": {
+        "name": "Antoine Cully",
+        "blog": "antoinecully.com"
+    },
+    "dctrud": {
+        "name": "David Trudgian",
+        "email": "dave@trudgian.net",
+        "bio": "Work and collaborations.\r\n\r\nPersonal code at https://git.randomroad.net",
+        "blog": "https://dctrud.sdf.org"
+    },
+    "serlophug": {
+        "name": "Sergio L\u00f3pez Huguet",
+        "email": "sergio.lophug@gmail.com",
+        "bio": "Ph.D Student "
+    },
+    "dependabot[bot]": {
+        "name": "dependabot[bot]"
+    },
+    "jbd": {
+        "name": "jbd",
+        "bio": "jbdenis.net"
+    },
+    "alhirzel": {
+        "name": "Alex Hirzel",
+        "bio": "easygoing thinker/tinkerer type",
+        "blog": "http://alex.hirzel.us/"
+    },
+    "smoe": {
+        "name": "Steffen M\u00f6ller",
+        "email": "steffen_moeller@gmx.de",
+        "blog": "http://tangiblecomputationalbiology.blogspot.com"
+    },
+    "github-actions[bot]": {
+        "name": "github-actions[bot]"
+    },
+    "victorsndvg": {
+        "name": "victorsndvg",
+        "email": "victorsv@gmail.com",
+        "bio": "Scientific software engineer",
+        "blog": "http://sourceforge.net/u/victorsndvg/profile/"
+    },
+    "arfon": {
+        "name": "Arfon Smith",
+        "bio": "Head of Data Science Mission Office @spacetelescope. Ex GitHubber. @zooniverse co-founder. Editor-in-chief of the Journal of Open Source Software.",
+        "blog": "arfon.org"
+    },
+    "bbbbbrie": {
+        "name": "Brie Carranza",
+        "bio": "I like Linux, reading, writing in Python or Go, containers and automation, music, broccoli, math, pizza, documentation, grammar and cute animals!",
+        "blog": "https://ransomwareroundup.com"
+    },
+    "dfornika": {
+        "name": "Dan Fornika",
+        "email": "dfornika@gmail.com",
+        "bio": "Genomics Specialist\r\n",
+        "blog": "https://orcid.org/0000-0002-6178-3585"
+    },
+    "RonaldEnsing": {
+        "name": "Ronald Ensing"
     }
 }

--- a/.tributors
+++ b/.tributors
@@ -1,20 +1,20 @@
 {
-    "vsoch": {
-        "name": "Vanessasaurus",
-        "bio": "I'm the Vanessasaurus!",
-        "blog": "https://vsoch.github.io"
-    },
     "yarikoptic": {
         "name": "Yaroslav Halchenko",
-        "bio": "Cheers!",
         "blog": "www.onerussian.com",
+        "email": "debian@onerussian.com",
+        "bio": "Cheers!",
         "orcid": "0000-0003-3456-2493",
-        "affiliation": "Dartmouth College",
-        "email": "debian@onerussian.com"
+        "affiliation": "Dartmouth College"
+    },
+    "vsoch": {
+        "name": "Vanessasaurus",
+        "blog": "https://vsoch.github.io",
+        "bio": "I'm the Vanessasaurus!"
     },
     "pgrimaud": {
         "name": "Pierre Grimaud",
-        "bio": "Technical Manager @bigyouth / IT Teacher / Retired gladiator",
-        "blog": "https://github.com/pgrimaud"
+        "blog": "https://github.com/pgrimaud",
+        "bio": "Technical Manager @bigyouth / IT Teacher / Retired gladiator"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/con/tributors/tree/master) (0.0.x)
+ - support for updating .tributors from a lookup (0.0.12)
  - adding codemeta as a parser (0.0.11)
  - refactor of GitHub action and container deployment (0.0.1)
  - skeleton release (0.0.0)

--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ See the full [documentation](https://con.github.io/tributors/) for getting start
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+## TODO:
+
+ - orcid and github should be resources? or just orcid?

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   parsers:
     description: space separated list of parsers to use. Defaults to unset (auto-detect)
     default: unset
+  update_lookup:
+    description: before running update, update the .tributors metadata file from these resources. Include custom filenames if necessary
+    required: false
   zenodo_file:
     description: .zenodo.json to update. If does not exist, must define doi variable
     default: .zenodo.json

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: space separated list of parsers to use. Defaults to unset (auto-detect)
     default: unset
   update_lookup:
-    description: before running update, update the .tributors metadata file from these resources. Include custom filenames if necessary
+    description: before running update, update the .tributors metadata file from these resources
     required: false
   zenodo_file:
     description: .zenodo.json to update. If does not exist, must define doi variable
@@ -27,6 +27,9 @@ inputs:
   codemeta_file:
     description: codemeta filename (skipped if not defined)
     default: codemeta.json
+  mailmap_file:
+    description: A mailmap file for update-lookup (defaults to .mailmap)
+    default: .mailmap
   allcontrib_file:
     description: All contributors filename (defaults to .all-contributorsrc)
     default: .all-contributorsrc

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,7 +53,7 @@ fi
 
 # First update via a lookup, if specified
 if [ ! -z "${INPUT_UPDATE_LOOKUP}" ]; then
-    tributors update-lookup "${INPUT_UPDATE_LOOKUP}"
+    tributors update-lookup ${INPUT_UPDATE_LOOKUP}
 fi
 
 # Update the user:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,7 +53,7 @@ fi
 
 # First update via a lookup, if specified
 if [ ! -z "${INPUT_UPDATE_LOOKUP}" ]; then
-    tributors update-lookup ${INPUT_UPDATE_LOOKUP}
+    tributors update-lookup "${INPUT_UPDATE_LOOKUP}" --mailmap-file "${INPUT_MAILMAP_FILE}" --allcontrib-file "${INPUT_ALLCONTRIB_FILE}" --zenodo-file "${INPUT_ZENODO_FILE}" --codemeta-file "${INPUT_CODEMETA_FILE}"
 fi
 
 # Update the user:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,6 +51,11 @@ elif [[ "${INPUT_PARSERS}" == *"allcontrib"* ]]; then
     RUN_ALLCONTRIB="true"
 fi
 
+# First update via a lookup, if specified
+if [ ! -z "${INPUT_UPDATE_LOOKUP}" ]; then
+    tributors update-lookup "${INPUT_UPDATE_LOOKUP}"
+fi
+
 # Update the user:
 printf "Run zenodo: ${RUN_ZENODO}\n"
 printf "Run allcontrib: ${RUN_ALLCONTRIB}\n"

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -629,20 +629,18 @@ dashes.
 | allcontrib_file |The all contributors file | false | .all-contributorsrc |
 | allcontrib_type |Contribution type, which defaults to "code" if not set. | false | code |
 | allcontrib_skip_generate | skip running all-contributors generate | false | false |
-| codemeta_file | the codemeta file to update, if defined | false | unset |
+| codemeta_file | the codemeta file to update, if defined | false | codemeta.json |
+| mailmap_file | the mailmap file to use for update-lookup, if needed | false | .mailmap |
 | update_lookup | one or more resources to use to update the .tributors file before running update | false | unset |
 
 If you define `update_lookup`, you should list the (space separated) names of the parsers that you want to use. For example:
 
 ```yaml
-   update_lookup: "mailmap"
+   update_lookup: mailmap zenodo
 ```
 
-And if you have a custom filename from the default, you should also include it here:
+The same file names (e.g., *_file) will be used.
 
-```yaml
-   update_lookup: "mailmap --mailmap-file subfolder/.mailmap
-```
 
 If you aren't familiar with all-contributors, you'll need to add some
 [commenting in your repository README](https://allcontributors.org/docs/en/cli/usage)

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -615,6 +615,9 @@ Inputs are listed below.
 
 #### Inputs
 
+The command line arguments for the action are equivalent but with underscores instead of
+dashes.
+
 | name | description | required | default |
 |------|-------------|----------|---------|
 | parsers | a space separated list of parsers (e.g., "zenodo allcontrib") or "all" or "unset" for autodetect | false | unset | 
@@ -626,7 +629,20 @@ Inputs are listed below.
 | allcontrib_file |The all contributors file | false | .all-contributorsrc |
 | allcontrib_type |Contribution type, which defaults to "code" if not set. | false | code |
 | allcontrib_skip_generate | skip running all-contributors generate | false | false |
-| codemeta-file | the codemeta file to update, if defined | false | unset |
+| codemeta_file | the codemeta file to update, if defined | false | unset |
+| update_lookup | one or more resources to use to update the .tributors file before running update | false | unset |
+
+If you define `update_lookup`, you should list the (space separated) names of the parsers that you want to use. For example:
+
+```yaml
+   update_lookup: "mailmap"
+```
+
+And if you have a custom filename from the default, you should also include it here:
+
+```yaml
+   update_lookup: "mailmap --mailmap-file subfolder/.mailmap
+```
 
 If you aren't familiar with all-contributors, you'll need to add some
 [commenting in your repository README](https://allcontributors.org/docs/en/cli/usage)

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -12,6 +12,86 @@ description: Getting started with tributors
 This guide will provide getting started instructions for local and Docker Usage,
 along with GitHub Workflows.
 
+## Concepts
+
+### A Contributors File
+
+A contributors file is something like a `.zenodo.json`, a `codemeta.json`, or
+an `.all-contributorsrc`. It's a file that you might find in your repository,
+and it generally has metadata including a list of contributors. Tributors lets you
+interact with (create or update these files) via the `tributors update` command.
+
+```bash
+# auto-detect metadata files in the present working directory
+$ tributors update
+
+# target a specific metadata file, .all-contributorsrc
+$ tributors update allcontrib
+```
+
+### A Tributors Cache File
+
+To share metadata between these files, tributors uses a shared cache, the 
+[.tributors]({{ site.baseurl }}/docs/tributors) file. This file is updated when
+you run `tributors update` in the case that any of your metadata files have additional
+information on a person. For example, let's say that we have a list of contributors
+in an `.zenodo.json`, but they are missing Orcid Ids. By default, tributors will ping
+the GitHub API to look for new contributors, and during this process we might
+discover email addresses. We can then use the email addresses to query the Orcid API
+and discover the correct identifiers. The associated emails, names, and orcid ids
+are then stored to the .tributors cache file. If any future call using a metadata
+parser is looking for one of these fields, we will find it there.
+
+### Lookup From
+
+By default, whenever you issue a `tributors update` command, since the code lives in
+a GitHub repository and we are looking for contributors, we ping the GitHub API to
+find them. We can view this as a tributors resource, or basically any endpoint,
+service, or file that we can use to discover contributors. We are basically saying:
+
+> Tributors, update my metadata file with contributors __from__ github.
+
+However, let's say that we have two metadata files, an .all-contributorsrc
+and .zenodo.json. By default they will (separately) be updated via the GitHub 
+contributors API endpoint, and also share metadata via the .tributors cache.
+But what if there are contributors in one of the files that we want to 
+add to the other, and those contributors aren't found in the GitHub API (and
+thus would not be added?) We would equivalently want to say:
+
+> Tributors, update my metadata file with contributors __from__ this other metadata file.
+
+And in fact, we can do this with `tributors update` by adding the `--from` argument.
+
+```bash
+$ tributors update allcontrib --from zenodo
+```
+
+(note that this feature is currently under development)
+
+### Update .tributors Cache
+
+There are many good places to find metadata about contributors that aren't necessary
+contributor files. For example, a `.mailmap` file would have a mapping between names
+and emails, and any of the previously mentioned files (.zenodo.json, .all-contributorsrc,
+or codemeta.json) can be used as a metadata lookup without touching a contributors
+metadata file. Let's say that we want to just update our .tributors shared metadata
+cache without touching any files. We can do that with `tributors update-lookup`:
+
+```bash
+# auto-detect lookup files in the present working directory
+$ tributors update-lookup
+
+# target a specific metadata file, .mailmap
+$ tributors update-lookup mailmap
+```
+
+This would update fields in our .tributors file, and then we could run `tributors update`
+on one or more contributor files to update them. Notice that for all operations,
+if a field is already defined it won't be over-written, as you might have edited
+it and don't want to lose those edits. You of course are free to update or otherwise
+manually edit all of these files to your liking.
+
+
 ## Quick Start
 
 ### 1. Install
@@ -68,6 +148,20 @@ $ tributors init zenodo
 You can read more about the various [parsers]({{ site.baseurl }}/docs/parsers)
 for specific-parser arguments, and more details about the above commands in the
 sections below.
+
+### 4. Update Lookups
+
+If you have a file that might be used as a lookup to find additional metadata
+fields (e.g., a .mailmap doesn't list contributors but has a list of names and emails)
+you can update your .tributors shared metadata cache using it before running `tributors update`:
+
+```bash
+# auto-detect known metadata files in the present working directory
+$ tributors update-lookup
+
+# update from a mailmap
+$ tributors update-lookup mailmap
+```
 
 ## Docker Usage
 

--- a/docs/_docs/parsers/allcontrib.md
+++ b/docs/_docs/parsers/allcontrib.md
@@ -141,6 +141,22 @@ Response 403: rate limit exceeded, cannot retrieve user RonaldEnsing.
 
 and definitely then should export a `GITHUB_TOKEN` to increase it!
 
+## Update .tributors
+
+Let's say that we have a local .all-contributorsrc, and we just want to use it to update our
+.tributors file. We could do:
+
+```bash
+$ tributors update-lookup allcontrib
+```
+
+And if you want it auto-discovered (with other known files) you can just do:
+
+```bash
+$ tributors update-lookup
+```
+
+
 ## Generate 
 
 Once you've update your .all-contributorsrc, you can either [install](https://allcontributors.org/docs/en/cli/overview) the

--- a/docs/_docs/parsers/codemeta.md
+++ b/docs/_docs/parsers/codemeta.md
@@ -55,6 +55,21 @@ You can also target a different filename;
 $ tributors update codemeta --codemeta-file codemeta.jsonld
 ```
 
-Since the cache is kept based on GitHub user id, we aren't able to store
+## Update .tributors
+
+Let's say that we have a local codemeta.json, and we just want to use it to update our
+.tributors file. We could do:
+
+```bash
+$ tributors update-lookup codemeta
+```
+
+And if you want it auto-discovered (with other known files) you can just do:
+
+```bash
+$ tributors update-lookup
+```
+
+For both of the above, since the cache is kept based on GitHub user id, we aren't able to store
 codemeta entries unless they have an email or orcid that we can match
 to an existing entry.

--- a/docs/_docs/parsers/index.md
+++ b/docs/_docs/parsers/index.md
@@ -17,5 +17,14 @@ currently supports several interfaces to common metadata formats:
  - [Zenodo](zenodo)
  - [Codemeta](codemeta)
 
+# Resources
+
+In addition to being able to update the contributor metadata file types listed
+above, tributors also can use some resource as a lookup to update the shared
+[.tributors]({{ site.baseurl }}/docs/tributors) cache. All of the parsers
+above can be used in this manner, and in addition, the following parsers
+allow for updating the metadata (but doesn't have it's own contributors file).
+
+ - [mailmap](mailmap)
 
 Would you like to see another metadata type? Please [open an issue])({{ site.repo }}/issues/new).

--- a/docs/_docs/parsers/mailmap.md
+++ b/docs/_docs/parsers/mailmap.md
@@ -1,0 +1,46 @@
+---
+title: Mailmap
+description: How to interact with a Mailmap fle
+---
+
+# MailMap
+
+A mailmap file (typically .mailmap) can be used as a lookup to match emails
+with names, so it's a good resource to look to update the shared [.tributors]({{ site.baseurl }}/docs/tributors)
+cache. If you haven't already, make sure that you [install tributors]({{ site.baseurl }}/docs/getting-started#1-install-tributors).
+Here we show basic commands for interacting with the allcontrib generator, and a table of optional arguments.
+
+## Optional Arguments
+
+| name | description | required | default |
+|------|-------------|----------|---------|
+| `--mailmap-file` | .mailmap to use as a lookup | false | .mailmap | 
+
+## Update .tributors
+
+Let's say that we have a local mailmap file, it might look like this:
+
+```
+Yaroslav O. Halchenko <debian@onerussian.com>
+Yaroslav O. Halchenko <site-github-private@onerussian.com>
+Valentina Borghesani <vborghe@users.noreply.github.com>
+Marie-Luise Kieseler <kieseler.gr@dartmouth.edu>
+Cyril Pernet <wamcyril@gmail.com>
+Cyril Pernet <cyril.pernet@ed.ac.uk>
+Stephan Heunis <jsheunis@gmail.com>
+P.-J. Toussaint <4642250+pjtoussaint@users.noreply.github.com>
+```
+
+We would be able to update our .tributors file doing the following:
+
+```bash
+$ tributors update-lookup mailmap
+```
+
+And if you want it auto-discovered (with other known files) you can just do:
+
+```bash
+$ tributors update-lookup
+```
+
+You can also provide the filename via `--mailmap-file` if different from the default.

--- a/docs/_docs/parsers/zenodo.md
+++ b/docs/_docs/parsers/zenodo.md
@@ -17,8 +17,8 @@ Here we show basic commands for interacting with the allcontrib generator, and a
 
 | name | description | required | default |
 |------|-------------|----------|---------|
-| `--zenodo_file` | .zenodo.json to update. If does not exist, must define zenodo_doi | false | .zenodo.json | 
-| `--zenodo_doi` | Zenodo DOI needed for init. Leave unset to skip init. | false | unset | 
+| `--zenodo-file` | .zenodo.json to update. If does not exist, must define zenodo_doi | false | .zenodo.json | 
+| `--zenodo-doi` | Zenodo DOI needed for init. Leave unset to skip init. | false | unset | 
 | `--log-level` | Log level to use, one of INFO, DEBUG, CRITICAL, ERROR, WARNING, FATAL (default INFO) | false | INFO | 
 | `--thresh` | the minimum number of contributions required to add a user | false | 1 | 
 | `--force` | if files exist, force overwrit | false | false |
@@ -62,4 +62,20 @@ $ tributors update zenodo
 INFO:zenodo:Updating .zenodo.json
 ```
 
-You can also provide the filename via `--zenodo-file` if different from the default.
+## Update .tributors
+
+Let's say that we have a local .zenodo.json, and we just want to use it to update our
+.tributors file. We could do:
+
+```bash
+$ tributors update-lookup zenodo
+```
+
+And if you want it auto-discovered (with other known files) you can just do:
+
+```bash
+$ tributors update-lookup
+```
+
+
+For both update and update-lookup you can also provide the filename via `--zenodo-file` if different from the default.

--- a/docs/_docs/tributors.md
+++ b/docs/_docs/tributors.md
@@ -9,8 +9,8 @@ description: The .tributors file is a shared metadata file.
 
 # The Tributors File
 
-You can save a single metadata file in your repository that includes common fields
-to use to update other metadata files. As an example, here we see a file generated
+After running a `tributors update`, you'll save a single metadata file in your repository that includes common fields
+to use to update other metadata files, the ".tributors" file. As an example, here we see a file generated
 after an initial run - we index by the GitHub username since on GitHub that is our
 "unit of truth." These are a few entries for Singularity Registry Server:
 
@@ -50,9 +50,14 @@ $ cat .tributors
 ```
 
 You'll notice that we only save fields that we can find (e.g., if no email is
-exposed, it won't be defined. At this point we might want to update metadata
+exposed, it won't be defined. 
+
+## Manual Update
+
+At this point we might want to manually update metadata
 to our liking - any particular subfield for a user won't be overwritten if it's
-already defined.
+already defined. For example, my GitHub name from the API is "Vanessasaurus" and
+I might want to put a different name for a "professional" repository:
 
 ```bash
 $ cat .tributors 
@@ -102,6 +107,39 @@ $ cat .tributors
     }
 }
 ```
+
+Notice that for all operations, if a field is already defined it won't be over-written, as you might have edited
+it and don't want to lose those edits. You of course are free to update or otherwise
+manually edit all of these files to your liking.
+
+## Automated Update
+
+Along with providing parsers to update specific contributor files (e.g., .zenodo.json uses
+a Zenodo parser) tributors also provides these parsers (and other resources for metadata)
+that can be used to update the .tributors file. For example, a `.mailmap` file would have a mapping between names
+and emails, and any of the parsers that have contributors files (e.g., Zenodo, All Contributors,
+or CodeMeta) can also be used as metadata lookups without touching a contributors
+metadata file. We do this by way of the `update-lookup` command. Let's say that we 
+want to just update our .tributors shared metadata cache from known lookups
+we find in the present working directory:
+
+```bash
+# auto-detect lookup files in the present working directory
+$ tributors update-lookup
+```
+or from a particular source such as a mailmap file:
+```
+# target a specific metadata file, .mailmap
+$ tributors update-lookup mailmap
+```
+
+This would update fields in our .tributors file, and then we could run `tributors update`
+to pass on new metadata files into our contributor files. To read more about resources
+that are available to update the .tributors file, see the [parsers]({{ site.baseurl }}/docs/parsers)
+documentation.
+
+
+## Fields
 
 The following fields are known to a `.tributors` file
 

--- a/examples/generate-artifacts.yml
+++ b/examples/generate-artifacts.yml
@@ -18,8 +18,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:        
 
-          # Single text list (space separated) of parsers, or all (default)
-          parsers: all
+          # Single text list (space separated) of parsers, all, or auto-detect (default when "unset")
+          parsers: unset
+
+          # One or more resources (and optional arguments) to update .tributors
+          update_lookup: mailmap 
+ 
+          # This file will be used for running update-lookup
+          mailmap_file: "tests/.mailmap"
 
           # INFO, DEBUG, ERROR, WARNING, etc.
           log_level: DEBUG

--- a/tests/.mailmap
+++ b/tests/.mailmap
@@ -1,0 +1,8 @@
+Yaroslav O. Halchenko <debian@onerussian.com>
+Yaroslav O. Halchenko <site-github-private@onerussian.com>
+Valentina Borghesani <vborghe@users.noreply.github.com>
+Marie-Luise Kieseler <kieseler.gr@dartmouth.edu>
+Cyril Pernet <wamcyril@gmail.com>
+Cyril Pernet <cyril.pernet@ed.ac.uk>
+Stephan Heunis <jsheunis@gmail.com>
+P.-J. Toussaint <4642250+pjtoussaint@users.noreply.github.com>

--- a/tests/codemeta.json
+++ b/tests/codemeta.json
@@ -1,0 +1,172 @@
+{
+    "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+    "@type": "SoftwareSourceCode",
+    "identifier": "CodeMeta",
+    "description": "CodeMeta is a concept vocabulary that can be used to standardize the exchange of software metadata across repositories and organizations.",
+    "name": "CodeMeta: Minimal metadata schemas for science software and code, in JSON-LD",
+    "codeRepository": "https://github.com/codemeta/codemeta",
+    "issueTracker": "https://github.com/codemeta/codemeta/issues",
+    "license": "https://spdx.org/licenses/Apache-2.0",
+    "version": "2.0",
+    "author": [
+        {
+            "@type": "Person",
+            "givenName": "Carl",
+            "familyName": "Boettiger",
+            "email": "cboettig@gmail.com",
+            "@id": "http://orcid.org/0000-0002-1642-628X"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Matthew B.",
+            "familyName": "Jones",
+            "email": "jones@nceas.ucsb.edu",
+            "@id": "http://orcid.org/0000-0003-0077-4738"
+        }
+    ],
+    "contributor": [
+        {
+            "@type": "Person",
+            "givenName": "Abby Cabunoc",
+            "familyName": "Mayes",
+            "email": "abbycabs@gmail.com"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Arfon",
+            "familyName": "Smith",
+            "email": "arfon.smith@gmail.com",
+            "@id": "http://orcid.org/0000-0002-3957-2474"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Peter",
+            "familyName": "Slaughter",
+            "email": "slaughter@nceas.ucsb.edu",
+            "@id": "http://orcid.org/0000-0002-2192-403X"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Kyle",
+            "familyName": "Niemeyer",
+            "email": "Kyle.Niemeyer@oregonstate.edu",
+            "@id": "http://orcid.org/0000-0003-4425-7097"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Yolanda",
+            "familyName": "Gil",
+            "email": "GIL@ISI.EDU",
+            "@id": "http://orcid.org/0000-0001-8465-8341"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Krzysztof",
+            "familyName": "Nowak"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Martin",
+            "familyName": "Fenner",
+            "@id": "http://orcid.org/0000-0003-1419-2405"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Mark",
+            "familyName": "Hahnel",
+            "@id": "http://orcid.org/0000-0003-4741-0309"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Luke",
+            "familyName": "Coy",
+            "email": "luke.coy@rit.edu"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Alice",
+            "familyName": "Allen",
+            "email": "aallen@ascl.net",
+            "@id": "http://orcid.org/0000-0003-3477-2845"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Merc\u00e8",
+            "familyName": "Crosas",
+            "@id": "http://orcid.org/0000-0003-1304-1939"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Ashley",
+            "familyName": "Sands",
+            "@id": "http://orcid.org/0000-0001-5636-0433"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Neil",
+            "familyName": "Chue Hong",
+            "email": "n.chuehong@epcc.ed.ac.uk",
+            "@id": "http://orcid.org/0000-0002-8876-7606"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Patricia",
+            "familyName": "Cruse",
+            "@id": "http://orcid.org/0000-0002-9300-5278"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Dan",
+            "familyName": "Katz",
+            "email": "dskatz@illinois.edu",
+            "@id": "http://orcid.org/0000-0003-2720-0339"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Carole",
+            "familyName": "Goble",
+            "email": "carole.goble@manchester.ac.uk",
+            "@id": "http://orcid.org/0000-0003-1219-2137"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Carl",
+            "familyName": "Boettiger",
+            "email": "cboettig@gmail.com",
+            "@id": "http://orcid.org/0000-0002-1642-628X"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Stephan",
+            "familyName": "Druskat",
+            "email": "mail@sdruskat.net",
+            "@id": "http://orcid.org/0000-0003-4925-7248"
+        }
+    ],
+    "maintainer": {
+        "@type": "Person",
+        "givenName": "Carl",
+        "familyName": "Boettiger",
+        "email": "cboettig@gmail.com",
+        "@id": "http://orcid.org/0000-0002-1642-628X"
+    },
+    "contIntegration": "https://travis-ci.org/codemeta/codemeta",
+    "developmentStatus": "active",
+    "downloadUrl": "https://github.com/codemeta/codemeta/archive/2.0.zip",
+    "funder": {
+        "@id": "https://doi.org/10.13039/100000001",
+        "@type": "Organization",
+        "name": "National Science Foundation"
+    },
+    "funding": "1549758; Codemeta: A Rosetta Stone for Metadata in Scientific Software",
+    "keywords": [
+        "metadata",
+        "allcontributors",
+        "contributors",
+        "software",
+        "zenodo"
+    ],
+    "dateCreated": "2017-06-05",
+    "datePublished": "2017-06-05",
+    "programmingLanguage": "JSON-LD"
+}

--- a/tests/test_client.sh
+++ b/tests/test_client.sh
@@ -38,11 +38,35 @@ echo
 echo "#### Testing init with malformed name"
 runTest 1 $output tributors init --allcontrib-file $tmpdir/.all-contributorsrc --repo pancakes-hub
 
-
+echo
 echo "#### Testing update zenodo"
 runTest 0 $output tributors update zenodo --zenodo-file $tmpdir/.zenodo.json
 
+echo
 echo "#### Testing update allcontrib"
 runTest 0 $output tributors update allcontrib --allcontrib-file $tmpdir/.all-contributorsrc
+
+echo
+echo "#### Testing update-lookup allcontrib"
+runTest 0 $output tributors update-lookup allcontrib --allcontrib-file $tmpdir/.all-contributorsrc
+
+echo
+echo "#### Testing update-lookup mailmap"
+runTest 0 $output tributors update-lookup mailmap --mailmap-file $here/.mailmap
+runTest 1 $output tributors update-lookup mailmap
+
+echo
+echo "#### Testing update-lookup zenodo"
+runTest 0 $output tributors update-lookup zenodo --zenodo-file $tmpdir/.zenodo.json
+runTest 1 $output tributors update-lookup zenodo
+
+echo
+echo "#### Testing update-lookup codemeta"
+runTest 0 $output tributors update-lookup codemeta --codemeta-file $here/codemeta.json
+runTest 1 $output tributors update-lookup codemeta
+
+echo
+echo "#### Testing update-lookup (discover)"
+runTest 0 $output tributors update-lookup
 
 rm -rf ${tmpdir}

--- a/tributors/client/__init__.py
+++ b/tributors/client/__init__.py
@@ -22,7 +22,7 @@ def get_parser():
     parser = argparse.ArgumentParser(description="Tributors Python Metadata Parser")
 
     parser.add_argument(
-        "--log_level",
+        "--log-level",
         dest="log_level",
         choices=LOG_LEVELS,
         default=LOG_LEVEL,
@@ -66,6 +66,18 @@ def get_parser():
 
     # print version and exit
     subparsers.add_parser("version", help="show software version")
+
+    # Update the .tributors lookup
+    update_lookup = subparsers.add_parser(
+        "update-lookup", help="Update shared .tributors metadata file",
+    )
+    update_lookup.add_argument(
+        "files",
+        help="One or more files to use for update.",
+        nargs="*",
+        default="unset",
+        choices=["mailmap", "allcontrib", "codemeta", "zenodo", "unset"],
+    )
 
     # Update an existing contributors file
     update = subparsers.add_parser("update", help="Update existing all-contributorsrc",)
@@ -125,6 +137,8 @@ def main():
         from .init import main
     elif args.command == "update":
         from .update import main
+    elif args.command == "update-lookup":
+        from .lookup import main
     else:
         help()
 

--- a/tributors/client/lookup.py
+++ b/tributors/client/lookup.py
@@ -22,32 +22,30 @@ def main(args, extra):
     extra = parse_extra(extra)
 
     # Start with user provided parsers
-    parsers = args.parsers
+    resources = args.files
 
     # If unset, try to detect files
-    if "unset" in parsers:
+    if "unset" in resources:
         lookup = {
             "allcontrib": extra.get("--allcontrib-file", ".all-contributorsrc"),
             "zenodo": extra.get("--zenodo-file", ".zenodo.json"),
             "codemeta": extra.get("--codemeta-file", "codemeta.json"),
+            "mailmap": extra.get("--mailmap-file", ".mailmap"),
         }
 
-        parsers = []
-        for parser, filename in lookup.items():
+        resources = []
+        for resource, filename in lookup.items():
             if os.path.exists(filename):
-                parsers.append(parser)
+                resources.append(resource)
 
         # Exit if no parsers auto-detected
-        if not parsers:
-            sys.exit("No parsers auto-detected. Specify a parser name instead?")
+        if not resources:
+            sys.exit("No resources auto-detected. Specify one or more instead?")
 
-    if "all" in parsers:
-        client.update(
-            parsers=["zenodo", "allcontrib", "codemeta"],
-            thresh=args.thresh,
-            repo=args.repo,
-            params=extra,
+    if "all" in resources:
+        client.update_resource(
+            resources=["zenodo", "allcontrib", "codemeta", "mailmap"], params=extra,
         )
 
     else:
-        client.update(parsers=parsers, repo=args.repo, params=extra, thresh=args.thresh)
+        client.update_resource(resources=resources, params=extra)

--- a/tributors/client/utils.py
+++ b/tributors/client/utils.py
@@ -20,6 +20,7 @@ def parse_extra(extra):
         "--allcontrib-type",
         "--allcontrib-file",
         "--codemeta-file",
+        "--mailmap-file",
     ]
     known_bool = []
 

--- a/tributors/main/__init__.py
+++ b/tributors/main/__init__.py
@@ -76,6 +76,19 @@ class TributorsClient:
         # Save the cache
         self.save_cache()
 
+    def update_resource(self, resources=None, params=None):
+        """Given one or more resource types (an external file or source of
+           metadata) update the .tributors cache lookup
+        """
+        resources = resources or []
+        for name in resources:
+            resource = get_named_parser(name=name, params=params)
+            resource.cache = self.cache
+            resource.update_lookup()
+
+        # Save the cache
+        self.save_cache()
+
     def update(self, parsers=None, repo=None, params=None, thresh=1):
         """Update one or more contributor parsers. Specifically, this is the
            action that runs the parser.update() after obtaining contributions
@@ -88,10 +101,10 @@ class TributorsClient:
         repo = GitHubRepository(repo)
 
         for parser in parsers:
-            client = get_named_parser(parser, repo)
+            client = get_named_parser(name=parser, repo=repo, params=params)
             client.orcid_token = self.orcid_token
             client.cache = self.cache
-            client.update(params=params, thresh=thresh)
+            client.update(thresh=thresh)
             self.cache.update(client.cache)
 
         # Save the cache

--- a/tributors/main/__init__.py
+++ b/tributors/main/__init__.py
@@ -68,9 +68,9 @@ class TributorsClient:
         repo = GitHubRepository(repo)
 
         for parser in parsers:
-            client = get_named_parser(parser, repo)
+            client = get_named_parser(name=parser, repo=repo, params=params)
             client.cache = self.cache
-            client.init(params=params, force=force)
+            client.init(force=force)
             self.cache.update(client.cache)
 
         # Save the cache

--- a/tributors/main/github.py
+++ b/tributors/main/github.py
@@ -117,10 +117,13 @@ def get_contributors(repo):
     headers = get_headers()
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
-        sys.exit(
-            "Response %s: %s, cannot retrieve contributors."
+        message = ("Response %s from GitHub: %s, cannot retrieve contributors "
             % (response.status_code, response.reason)
         )
+        if not os.environ.get("GITHUB_TOKEN"):
+           message += " you should export GITHUB_TOKEN to increase your API limits"
+        sys.exit(message)
+
     # Return a lookup based on GitHub Login
     return {x["login"]: x for x in response.json()}
 
@@ -144,7 +147,7 @@ def get_user(username):
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
         sys.exit(
-            "Response %s: %s, cannot retrieve user %s."
+            "Response %s: %s, cannot retrieve GitHub user %s."
             % (response.status_code, response.reason, username)
         )
     return response.json()

--- a/tributors/main/github.py
+++ b/tributors/main/github.py
@@ -117,11 +117,12 @@ def get_contributors(repo):
     headers = get_headers()
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
-        message = ("Response %s from GitHub: %s, cannot retrieve contributors "
-            % (response.status_code, response.reason)
+        message = "Response %s from GitHub: %s, cannot retrieve contributors " % (
+            response.status_code,
+            response.reason,
         )
         if not os.environ.get("GITHUB_TOKEN"):
-           message += " you should export GITHUB_TOKEN to increase your API limits"
+            message += " you should export GITHUB_TOKEN to increase your API limits"
         sys.exit(message)
 
     # Return a lookup based on GitHub Login

--- a/tributors/main/parsers/__init__.py
+++ b/tributors/main/parsers/__init__.py
@@ -11,19 +11,30 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from .allcontrib import AllContribParser
 from .codemeta import CodeMetaParser
 from .zenodo import ZenodoParser
+from .mailmap import MailmapParser
 import re
 
 
-def get_named_parser(name, repo=None, filename=None):
-    """get a named parser, meaning determining based on name and not uri
+def get_named_parser(name, repo=None, filename=None, params=None):
+    """get a named parser, meaning determining based on name and not uri.
+       Typically a parser is used to update a metadata file and also
+       update the shared .tributors cache, but in a few cases (where we don't
+       have any metadata file to update) the parser is just used as a resource
+       to update the cache.
     """
     parser = None
+
+    # These parsers have contributors files, and used to update .tributors
     if re.search("(allcontrib|all-contrib)", name):
-        parser = AllContribParser(filename, repo)
+        parser = AllContribParser(filename, repo, params)
     elif re.search("zenodo", name):
-        parser = ZenodoParser(filename, repo)
+        parser = ZenodoParser(filename, repo, params)
     elif re.search("codemeta", name):
-        parser = CodeMetaParser(filename, repo)
+        parser = CodeMetaParser(filename, repo, params)
+
+    # These parsers only update .tributors metadata
+    elif re.search("mailmap", name):
+        parser = MailmapParser(filename=filename, params=params)
 
     if not parser:
         raise NotImplementedError(f"There is no matching parser for {name}")

--- a/tributors/main/parsers/base.py
+++ b/tributors/main/parsers/base.py
@@ -91,7 +91,7 @@ class ParserBase:
             return False
         return True
 
-    def update_cache(self):
+    def update_cache(self, update_lookup=True):
         """A shared function to get updated GitHub contributors to update
            the local cache. This is where we parse all the data that we need 
            and return common fields that some given parser might need.
@@ -135,5 +135,5 @@ class ParserBase:
             self.cache[login] = entry
 
         # If the parser can be used as a resource, use it to update .tributors
-        if hasattr(self, "update_lookup"):
+        if hasattr(self, "update_lookup") and update_lookup:
             self.update_lookup()

--- a/tributors/main/parsers/mailmap.py
+++ b/tributors/main/parsers/mailmap.py
@@ -1,0 +1,71 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+import logging
+import os
+import sys
+
+from tributors.utils.file import read_file
+from .base import ParserBase
+
+bot = logging.getLogger("   mailmap")
+
+
+class MailmapParser(ParserBase):
+
+    name = "mailmap"
+
+    def __init__(self, filename=None, params=None, **kwargs):
+        filename = filename or ".mailmap"
+        super().__init__(filename=filename, params=params)
+
+    def load_data(self):
+        """Since mailmap has format Name <email> on each line, we have a custom
+           loading function, and we don't ever need to write anything
+        """
+        if not self.data:
+            self.filename = self.params.get("--mailmap-file", self.filename)
+
+            # Ensure codemeta file already exists
+            if not os.path.exists(self.filename):
+                sys.exit("%s does not exist" % self.filename)
+
+            for line in read_file(self.filename):
+                name, email = line.split("<")
+                email = email.strip().rstrip(">")
+                self.data[email] = name.strip()
+        return self.data
+
+    @property
+    def email_lookup(self):
+        """Return loaded metadata as an email lookup. In this case, this
+           is just the entire data.
+        """
+        if not hasattr(self, "_email_lookup"):
+            self.load_data()
+            self._email_lookup = self.data
+        return self._email_lookup
+
+    def update_lookup(self):
+        """Each client optionally has it's own function to update the cache.
+            In the case of zenodo, we aren't necessarily aware of GitHub
+            login (the current mapping mechanism) so we cannot update the
+            cache yet. When orcid is added this might be an option.
+        """
+        bot.info(f"Updating .tributors cache from {self.filename}")
+        self.load_data()
+
+        # Find matches based on email
+        for login, cache in self.cache.items():
+            email = cache.get("email")
+            if email in self.email_lookup:
+                if "name" not in cache:
+                    cache["name"] = self.email_lookup[email]
+                    bot.info(f"   Updating {login} with name: {cache['name']}")

--- a/tributors/main/parsers/zenodo.py
+++ b/tributors/main/parsers/zenodo.py
@@ -50,7 +50,7 @@ class ZenodoParser(ParserBase):
 
         # Assume we want to add known contributors
         creators = record["metadata"].get("creators", [])
-        self.update_cache()
+        self.update_cache(update_lookup=False)
 
         for login, _ in self.repo.contributors.items():
 
@@ -84,7 +84,7 @@ class ZenodoParser(ParserBase):
         """
         self.thresh = thresh
         self.load_data()
-        bot.info("Updating %s" % self.fliename)
+        bot.info("Updating %s" % self.filename)
 
         # We don't currently have a reliable identifier for zenodo, so we recreate each time
         self.lookup = self.data.get("creators", [])
@@ -111,7 +111,7 @@ class ZenodoParser(ParserBase):
             creators.append(entry)
 
         self.data["creators"] = creators
-        write_json(self.data, self.fliename)
+        write_json(self.data, self.filename)
         return self.data
 
     def update_lookup(self):

--- a/tributors/main/parsers/zenodo.py
+++ b/tributors/main/parsers/zenodo.py
@@ -13,32 +13,35 @@ import requests
 import os
 import sys
 
-from tributors.utils.file import read_json, write_json
+from tributors.utils.file import write_json
 from .base import ParserBase
 
-bot = logging.getLogger("zenodo")
+bot = logging.getLogger("    zenodo")
 
 
 class ZenodoParser(ParserBase):
 
     name = "zenodo"
 
-    def __init__(self, filename=None, repo=None, **kwargs):
+    def __init__(self, filename=None, repo=None, params=None, **kwargs):
         filename = filename or ".zenodo.json"
-        super().__init__(filename, repo)
+        super().__init__(filename, repo, params)
 
-    def init(self, params=None, force=False, contributors=None):
+    def load_data(self):
+        """A shared function to load the zenodo file, if data is not defined
+        """
+        return self._load_data("--zenodo-file")
+
+    def init(self, force=False):
         """Generate an empty .zenodo.json if it doesn't exist
         """
-        params = params or {}
-
         # A doi is required
-        doi = params.get("--doi")
+        doi = self.params.get("--doi")
         if not doi:
             sys.exit("Please provide the zenodo doi with --doi")
 
         # Zenodo file defaults to expected .zenodo.json
-        zenodo_file = params.get("--zenodo-file", self.filename)
+        zenodo_file = self.params.get("--zenodo-file", self.filename)
         if os.path.exists(zenodo_file) and not force:
             sys.exit("%s exists, set --force to overwrite." % zenodo_file)
 
@@ -75,23 +78,16 @@ class ZenodoParser(ParserBase):
         write_json(metadata, zenodo_file)
         return metadata
 
-    def update(self, params=None, contributors=None, thresh=1):
+    def update(self, thresh=1):
         """Given an existing .zenodo.json file, update it with contributors
            from an allcontributors file.
         """
-        params = params or {}
         self.thresh = thresh
-        zenodo_file = params.get("--zenodo-file", self.filename)
-
-        # Ensure contributors file and zenodo.json exist
-        if not os.path.exists(zenodo_file):
-            sys.exit("%s does not exist" % zenodo_file)
-
-        bot.info("Updating %s" % zenodo_file)
+        self.load_data()
+        bot.info("Updating %s" % self.fliename)
 
         # We don't currently have a reliable identifier for zenodo, so we recreate each time
-        data = read_json(zenodo_file)
-        self.lookup = data.get("creators", [])
+        self.lookup = self.data.get("creators", [])
         creators = []
 
         self.update_cache()
@@ -114,17 +110,33 @@ class ZenodoParser(ParserBase):
                 entry["affilitation"] = cache["affiliation"]
             creators.append(entry)
 
-        data["creators"] = creators
-        write_json(data, zenodo_file)
-        return data
+        self.data["creators"] = creators
+        write_json(self.data, self.fliename)
+        return self.data
 
-    def _update_cache(self):
+    def update_lookup(self):
         """Each client optionally has it's own function to update the cache.
             In the case of zenodo, we aren't necessarily aware of GitHub
             login (the current mapping mechanism) so we cannot update the
             cache yet. When orcid is added this might be an option.
-         """
-        pass
+        """
+        self.load_data()
+        bot.info(f"Updating .tributors cache from {self.filename}")
+
+        # We have to update based on orcid
+        lookup = {}
+        for entry in self.data.get("creators", []):
+            if "orcid" in entry:
+                lookup[entry["orcid"]] = entry
+
+        # Now loop through cache
+        for login, cache in self.cache.items():
+            if "orcid" in cache and cache["orcid"] in lookup:
+                for field in ["name", "affiliation"]:
+                    if field in lookup[cache["orcid"]] and field not in cache:
+                        value = lookup[cache]["orcid"][field]
+                        bot.info(f"   Updating {login} with {field}: {value}")
+                        cache[field] = value
 
 
 def get_zenodo_record(doi):

--- a/tributors/version.py
+++ b/tributors/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "tributors"


### PR DESCRIPTION
This issue will address #28, namely that we might have one or more metadata files that we want to use to update our shared .tributors cache, and then run an update for it. E.g.,

```bash
# get names from a mapmal
$ tributors update-lookup mailmap

# update allcontrib and zenodo entries that are missing names
$ tributors update zenodo allcontrib
```

This is different from saying "update the zenodo file _from_ the allcontrib file_, that will be another PR where the user can do:

```bash
$ tributors update zenodo --from allcontrib
```