### PR TITLE
updating to allow save of unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/con/tributors/tree/master) (0.0.x)
+ - unicode characters allowed, and dont update users with orcids (0.0.16)
  - should allow for repository names with .git extension (0.0.15)
  - adding support to do updates `--from` (between) resources (0.0.14)
  - adding github to update-lookup, not doing by default (0.0.13)

--- a/tributors/main/parsers/zenodo.py
+++ b/tributors/main/parsers/zenodo.py
@@ -115,8 +115,11 @@ class ZenodoParser(ParserBase):
         """
         creators = []
         for user in self.data.get("creators", []):
+            orcid = user.get("orcid")
             name = user.get("name")
             email = user.get("email")
+            if orcid is not None:
+                continue
             if email or name and self.orcid_token is not None:
                 orcid = get_orcid(email=email, token=self.orcid_token, name=name)
                 if orcid:

--- a/tributors/utils/file.py
+++ b/tributors/utils/file.py
@@ -20,11 +20,15 @@ def write_json(json_obj, filename, pretty=True):
         - json_obj (dict) : the dict to print to json
         - filename (str)  : the output file to write to
     """
-    with open(filename, "w") as filey:
+    with open(filename, "w", encoding="utf8") as filey:
         if pretty:
-            filey.writelines(json.dumps(json_obj, indent=4, separators=(",", ": ")))
+            filey.writelines(
+                json.dumps(
+                    json_obj, indent=4, ensure_ascii=False, separators=(",", ": ")
+                )
+            )
         else:
-            filey.writelines(json.dumps(json_obj))
+            filey.writelines(json.dumps(json_obj), ensure_ascii=False)
     return filename
 
 

--- a/tributors/version.py
+++ b/tributors/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "tributors"


### PR DESCRIPTION
This will fix #43 so that unicode characters are correctly save, and also not look up user ids that already have an orcid defined. E.g., here is a local run for datalad:

```bash
$ tributors update zenodo
INFO:    zenodo:Updating .zenodo.json
INFO:    zenodo:Updating .tributors cache from .zenodo.json
WARNING:github:Found 4 results for C Lau, Vicky:

0000-0001-9374-7098
0000-0001-9750-2514
0000-0003-3181-8561
0000-0003-0925-2012
You should look these up and add the correct in your .tributors lookup
WARNING:tributors:zenodo does not support updating from names.
```

Signed-off-by: vsoch <vsochat@stanford.edu>