### PR TITLE
tweaking orcid search

### DIFF
--- a/.tributors
+++ b/.tributors
@@ -1,122 +1,16 @@
 {
-    "glalteva": {
-        "name": "glalteva",
-        "blog": "https://github.com/glalteva"
-    },
-    "adswa": {
-        "name": "adswa",
-        "blog": "https://github.com/adswa"
-    },
-    "chrhaeusler": {
-        "name": "chrhaeusler",
-        "blog": "https://github.com/chrhaeusler"
-    },
-    "soichih": {
-        "name": "soichih",
-        "blog": "https://github.com/soichih"
-    },
-    "mvdoc": {
-        "name": "mvdoc",
-        "blog": "https://github.com/mvdoc"
-    },
-    "mih": {
-        "name": "mih",
-        "blog": "https://github.com/mih"
-    },
     "yarikoptic": {
-        "name": "yarikoptic",
-        "blog": "https://github.com/yarikoptic"
-    },
-    "loj": {
-        "name": "loj",
-        "blog": "https://github.com/loj"
-    },
-    "feilong": {
-        "name": "feilong",
-        "blog": "https://github.com/feilong"
-    },
-    "jhpoelen": {
-        "name": "jhpoelen",
-        "blog": "https://github.com/jhpoelen"
-    },
-    "andycon": {
-        "name": "andycon",
-        "blog": "https://github.com/andycon"
-    },
-    "nicholsn": {
-        "name": "nicholsn",
-        "blog": "https://github.com/nicholsn"
-    },
-    "adelavega": {
-        "name": "adelavega",
-        "blog": "https://github.com/adelavega"
-    },
-    "kskyten": {
-        "name": "kskyten",
-        "blog": "https://github.com/kskyten"
-    },
-    "TheChymera": {
-        "name": "TheChymera",
-        "blog": "https://github.com/TheChymera"
-    },
-    "effigies": {
-        "name": "effigies",
-        "blog": "https://github.com/effigies"
-    },
-    "jgors": {
-        "name": "jgors",
-        "blog": "https://github.com/jgors"
-    },
-    "debanjum": {
-        "name": "debanjum",
-        "blog": "https://github.com/debanjum"
-    },
-    "nellh": {
-        "name": "nellh",
-        "blog": "https://github.com/nellh"
-    },
-    "emdupre": {
-        "name": "emdupre",
-        "blog": "https://github.com/emdupre"
-    },
-    "aqw": {
-        "name": "aqw",
-        "blog": "https://github.com/aqw"
+        "name": "Yaroslav Halchenko",
+        "blog": "www.onerussian.com",
+        "orcid": "0000-0003-3456-2493",
+        "affiliation": "Dartmouth College"
     },
     "vsoch": {
-        "name": "vsoch",
-        "blog": "https://github.com/vsoch"
+        "name": "Vanessasaurus",
+        "blog": "https://vsoch.github.io"
     },
-    "kyleam": {
-        "name": "kyleam",
-        "blog": "https://github.com/kyleam"
-    },
-    "driusan": {
-        "name": "driusan",
-        "blog": "https://github.com/driusan"
-    },
-    "overlake333": {
-        "name": "overlake333",
-        "blog": "https://github.com/overlake333"
-    },
-    "akeshavan": {
-        "name": "akeshavan",
-        "blog": "https://github.com/akeshavan"
-    },
-    "jwodder": {
-        "name": "jwodder",
-        "blog": "https://github.com/jwodder"
-    },
-    "bpoldrack": {
-        "name": "bpoldrack",
-        "blog": "https://github.com/bpoldrack"
-    },
-    "yetanothertestuser": {
-        "name": "yetanothertestuser",
-        "blog": "https://github.com/yetanothertestuser"
-    },
-    "bhanuprasad14": {
-        "name": "bhanuprasad14",
-        "blog": "https://github.com/bhanuprasad14"
+    "pgrimaud": {
+        "name": "Pierre Grimaud",
+        "blog": "https://github.com/pgrimaud"
     }
 }

--- a/.tributors
+++ b/.tributors
@@ -3,14 +3,17 @@
         "name": "Yaroslav Halchenko",
         "blog": "www.onerussian.com",
         "orcid": "0000-0003-3456-2493",
-        "affiliation": "Dartmouth College"
+        "affiliation": "Dartmouth College",
+        "bio": "Cheers!"
     },
     "vsoch": {
         "name": "Vanessasaurus",
-        "blog": "https://vsoch.github.io"
+        "blog": "https://vsoch.github.io",
+        "bio": "I'm the Vanessasaurus!"
     },
     "pgrimaud": {
         "name": "Pierre Grimaud",
-        "blog": "https://github.com/pgrimaud"
+        "blog": "https://github.com/pgrimaud",
+        "bio": "Technical Manager @bigyouth / IT Teacher / Retired gladiator"
     }
 }

--- a/.tributors
+++ b/.tributors
@@ -1,20 +1,122 @@
 {
+    "glalteva": {
+        "name": "glalteva",
+        "blog": "https://github.com/glalteva"
+    },
+    "adswa": {
+        "name": "adswa",
+        "blog": "https://github.com/adswa"
+    },
+    "chrhaeusler": {
+        "name": "chrhaeusler",
+        "blog": "https://github.com/chrhaeusler"
+    },
+    "soichih": {
+        "name": "soichih",
+        "blog": "https://github.com/soichih"
+    },
+    "mvdoc": {
+        "name": "mvdoc",
+        "blog": "https://github.com/mvdoc"
+    },
+    "mih": {
+        "name": "mih",
+        "blog": "https://github.com/mih"
+    },
     "yarikoptic": {
-        "name": "Yaroslav Halchenko",
-        "blog": "www.onerussian.com",
-        "email": "debian@onerussian.com",
-        "bio": "Cheers!",
-        "orcid": "0000-0003-3456-2493",
-        "affiliation": "Dartmouth College"
+        "name": "yarikoptic",
+        "blog": "https://github.com/yarikoptic"
+    },
+    "loj": {
+        "name": "loj",
+        "blog": "https://github.com/loj"
+    },
+    "feilong": {
+        "name": "feilong",
+        "blog": "https://github.com/feilong"
+    },
+    "jhpoelen": {
+        "name": "jhpoelen",
+        "blog": "https://github.com/jhpoelen"
+    },
+    "andycon": {
+        "name": "andycon",
+        "blog": "https://github.com/andycon"
+    },
+    "nicholsn": {
+        "name": "nicholsn",
+        "blog": "https://github.com/nicholsn"
+    },
+    "adelavega": {
+        "name": "adelavega",
+        "blog": "https://github.com/adelavega"
+    },
+    "kskyten": {
+        "name": "kskyten",
+        "blog": "https://github.com/kskyten"
+    },
+    "TheChymera": {
+        "name": "TheChymera",
+        "blog": "https://github.com/TheChymera"
+    },
+    "effigies": {
+        "name": "effigies",
+        "blog": "https://github.com/effigies"
+    },
+    "jgors": {
+        "name": "jgors",
+        "blog": "https://github.com/jgors"
+    },
+    "debanjum": {
+        "name": "debanjum",
+        "blog": "https://github.com/debanjum"
+    },
+    "nellh": {
+        "name": "nellh",
+        "blog": "https://github.com/nellh"
+    },
+    "emdupre": {
+        "name": "emdupre",
+        "blog": "https://github.com/emdupre"
+    },
+    "aqw": {
+        "name": "aqw",
+        "blog": "https://github.com/aqw"
     },
     "vsoch": {
-        "name": "Vanessasaurus",
-        "blog": "https://vsoch.github.io",
-        "bio": "I'm the Vanessasaurus!"
+        "name": "vsoch",
+        "blog": "https://github.com/vsoch"
     },
-    "pgrimaud": {
-        "name": "Pierre Grimaud",
-        "blog": "https://github.com/pgrimaud",
-        "bio": "Technical Manager @bigyouth / IT Teacher / Retired gladiator"
+    "kyleam": {
+        "name": "kyleam",
+        "blog": "https://github.com/kyleam"
+    },
+    "driusan": {
+        "name": "driusan",
+        "blog": "https://github.com/driusan"
+    },
+    "overlake333": {
+        "name": "overlake333",
+        "blog": "https://github.com/overlake333"
+    },
+    "akeshavan": {
+        "name": "akeshavan",
+        "blog": "https://github.com/akeshavan"
+    },
+    "jwodder": {
+        "name": "jwodder",
+        "blog": "https://github.com/jwodder"
+    },
+    "bpoldrack": {
+        "name": "bpoldrack",
+        "blog": "https://github.com/bpoldrack"
+    },
+    "yetanothertestuser": {
+        "name": "yetanothertestuser",
+        "blog": "https://github.com/yetanothertestuser"
+    },
+    "bhanuprasad14": {
+        "name": "bhanuprasad14",
+        "blog": "https://github.com/bhanuprasad14"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/con/tributors/tree/master) (0.0.x)
+ - searching orcid for other-names as final resort, requiring first/last (0.0.19)
  - searching for last, first and reverse for orcid lookup (0.0.18)
  - unicode characters allowed, and dont update users with orcids (0.0.17)
  - should allow for repository names with .git extension (0.0.15)

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -99,22 +99,10 @@ pip install tributors
 
 ### 2. Environment
 
-Especially if you need orcid ids in your metadata, for a first time go you
-should export an id and secret to interact with the Orcid API. It'a also recommended
-to export a GitHub token to increase your API limit:
+It's recommended to export a GitHub token to increase your API limit:
 
 ```bash
-export ORCID_ID=APP-XXXXXXX
-export ORCID_SECRET=12345678910111213141516171819202122
 export GITHUB_TOKEN=XXXXXXXXXXXXXXX
-```
-
-Once you generate an orcid token, it will be written to a temporary file,
-and you can read the file and export the variable for later discovery (and you'll
-no longer need the ID and secret):
-
-```bash
-export ORCID_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 ### 3. Update Lookups
@@ -151,6 +139,36 @@ or update a specific one:
 $ tributors update allcontrib
 $ tributors update zenodo
 $ tributors update codemeta
+```
+
+If the client finds more than one orcid identifier for a name, you'll be prompted
+to run in `--interactive` mode. Running in interactive mode will allow you
+to choose a number for each one:
+
+```bash
+$ tributors update zenodo --interactive
+INFO:    zenodo:Updating .zenodo.json
+INFO:    zenodo:Updating .tributors cache from .zenodo.json
+
+Meyer, Kyle
+======================================================
+[1]
+  Name: Meyer, Kyle
+  Orcid: 0000-0002-1933-2908
+  Institutions: University of California Davis, University of Michigan, University of Texas at Austin
+
+[2]
+  Name: Meyer, Kyle
+  Orcid: 0000-0001-8632-4425
+  Institutions: Kroger Co, Northeastern Ohio Medical University, University of Toledo, University of Toledo Medical Center
+
+[3]
+  Name: Meyer, Kyle
+  Orcid: 0000-0001-8846-7411
+  Institutions: University of Auckland, University of Oregon, University of Wisconsin Milwaukee
+
+Please enter a choice, or s to skip.
+[1:3 or s to skip] : 
 ```
 
 ### 3. Init
@@ -410,30 +428,6 @@ Tokens can also be exported to increase interaction limits with various APIs:
 export ZENODO_TOKEN=xxxxxx
 export GITHUB_TOKEN=xxxxxx
 ```
-
-If you want to link emails with Orcid id's, it is suggested to generate and export an `ORCID_TOKEN` to ensure that you can look up these identifiers based on email addresses. 
-However to disable this, simply export the token as "disabled"
-
-```bash
-export ORCID_TOKEN=disabled
-```
-
-In order to generate this token
-for the first time, you should export an `ORCID_ID` and `ORCID_SECRET` that you need to 
-generate in the [developer tools](https://orcid.org/developer-tools). The callback
-uri can be either one of the defaults that they provide (we don't use it).
-Once you have your id and secret, export them to the environment.
-
-```bash
-export ORCID_ID=xxxxxxxx
-export ORCID_SECRET=xxxxx
-```
-
-The `ORCID_TOKEN` and `ORCID_REFRESH_TOKEN` will be written to a temporary file,
-and you can export these in the future to be discovered by the tributors client.
-Subsequent requests use the token to interact with the [public search API](https://members.orcid.org/api/tutorial/search-orcid-registry). Note that we haven't
-yet implemented using the refresh token to request a new one, so if you
-hit this use case, please [open an issue](https://github.com/con/tributors/issues).
 
 ### 2. Generate
 

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -30,13 +30,14 @@ def test_queries(tmp_path):
     result = get_orcid(email="debian@onerussian.com")
     assert result == orcid_id
 
+    # Test search for other name
+    result = get_orcid(email=None, name="Ярослав Олеговіч Гальченко")
+    assert result == orcid_id
+
     # Test returning None
     result = get_orcid(email=None, name="Zumbudda")
     assert not result
 
     # Test find by other-names (can't do because more than one result)
-    # result =  get_orcid(email=None, name="Horea Christian")
-
-    # Test search for a unicode name
-    # This returns 94 results, mostly guys named Yaroslav, so not sure will work
-    # result = get_orcid(email=None, name="Ярослав Олеговіч Гальченко")
+    result = get_orcid(email=None, name="Horea Christian")
+    assert result == "0000-0001-7037-2449"

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+import os
+import pytest
+
+
+def test_queries(tmp_path):
+    """test that changing order of First Last and Last, First returns same result
+    """
+    from tributors.main.orcid import get_orcid, record_search
+
+    orcid_id = "0000-0003-3456-2493"
+
+    # Test different orders of name
+    result = get_orcid(email=None, name="Yaroslav Halchenko")
+    assert result == orcid_id
+    result = get_orcid(email=None, name="Halchenko, Yaroslav")
+    assert result == orcid_id
+
+    # Test lookup by email
+    result = get_orcid(email="debian@onerussian.com")
+    assert result == orcid_id
+
+    # Test returning None
+    result = get_orcid(email=None, name="Zumbudda")
+    assert not result
+
+    # Test find by other-names (can't do because more than one result)
+    # result =  get_orcid(email=None, name="Horea Christian")
+
+    # Test search for a unicode name
+    # This returns 94 results, mostly guys named Yaroslav, so not sure will work
+    # result = get_orcid(email=None, name="Ярослав Олеговіч Гальченко")

--- a/tributors/client/__init__.py
+++ b/tributors/client/__init__.py
@@ -91,6 +91,13 @@ def get_parser():
 
     for command in [update, init]:
         command.add_argument(
+            "--interactive",
+            dest="interactive",
+            help="Allow interactive selection of orcid ids.",
+            default=False,
+            action="store_true",
+        )
+        command.add_argument(
             "parsers",
             help="Metadata file parsers to update or initialize.",
             nargs="*",

--- a/tributors/client/init.py
+++ b/tributors/client/init.py
@@ -22,6 +22,7 @@ def main(args, extra):
 
     # Parse extra arguments
     extra = parse_extra(extra)
+    extra["--interactive"] = args.interactive
 
     # Skip users, if a space separated list is defined
     skip_users = []

--- a/tributors/client/update.py
+++ b/tributors/client/update.py
@@ -20,6 +20,7 @@ def main(args, extra):
 
     # Parse extra arguments
     extra = parse_extra(extra)
+    extra["--interactive"] = args.interactive
 
     # Start with user provided parsers
     parsers = args.parsers

--- a/tributors/main/__init__.py
+++ b/tributors/main/__init__.py
@@ -10,7 +10,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from tributors.main.parsers import get_named_parser
 from tributors.utils.file import write_json, read_json
-from .orcid import get_orcid_token
 from .github import GitHubRepository
 import logging
 import os
@@ -114,10 +113,10 @@ class TributorsClient:
            from GitHub or a cache.
         """
         parsers = parsers or []
-        self.orcid_token = get_orcid_token()
 
         # Generate a shared repository object
         repo = GitHubRepository(repo, skip_users=skip_users)
+        bot.debug(f"Found repository {repo}")
 
         # Get resource lookup ids (emails, orcids, logins)
         resources = self.get_resource_lookups(from_resources, params)
@@ -125,7 +124,6 @@ class TributorsClient:
         # Update each metadata file via its parser
         for parser in parsers:
             client = get_named_parser(name=parser, repo=repo, params=params)
-            client.orcid_token = self.orcid_token
             client.cache = self.cache
             client.update(thresh=thresh, from_resources=resources)
             self.cache.update(client.cache)

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -182,6 +182,12 @@ def get_orcid(email, token, name=None):
         cleaner = "," if delim == " " else " "
 
         parts = name.split(delim)
+
+        # No go if only a first or last name
+        if len(parts) == 1:
+            bot.debug(f"Skipping {name}, first and last are required for search.")
+            break
+
         last, first = parts[0].strip(cleaner), " ".join(parts[1:]).strip(cleaner)
         url = (
             "https://pub.orcid.org/v3.0/search/?q=given-names:%s+AND+family-name:%s"
@@ -203,6 +209,11 @@ def get_orcid(email, token, name=None):
                 "https://pub.orcid.org/v3.0/search/?q=given-names:%s+AND+family-name:%s"
                 % (last, first)
             )
+            orcid_id = record_search(url, token, name)
+
+        # Last attempt looks in "Other names"
+        if orcid_id is None:
+            url = "https://pub.orcid.org/v3.0/search/?q=other-names:%s" % (name)
             orcid_id = record_search(url, token, name)
 
     return orcid_id

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -9,6 +9,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
 from tributors.utils.file import write_file, get_tmpfile
+from tributors.utils.prompt import choice_prompt
 import logging
 import os
 import requests
@@ -20,11 +21,10 @@ class OrcidIdentifier:
     """A simple class to retrieve an orcid record, and expose needed fields
     """
 
-    def __init__(self, orcid, token=None):
+    def __init__(self, orcid):
         self.orcid = orcid
         self._record = {}
         self.found = False
-        self.token = token
 
     def __str__(self):
         if self.orcid:
@@ -38,7 +38,7 @@ class OrcidIdentifier:
     def record(self):
         """Given an orcid id, retrieve a record for it
         """
-        if not self._record and self.orcid and self.token:
+        if not self._record and self.orcid:
             self.get_record()
         return self._record
 
@@ -92,7 +92,8 @@ class OrcidIdentifier:
 def get_orcid_token():
     """If the user has exported a token, we discover and return it here.
        Otherwise we prompt him or her to open a browser and copy paste a code
-       to the calling client.
+       to the calling client. This is currently not used, but kept in case
+       we need to add it back.
     """
     orcid_token = os.environ.get("ORCID_TOKEN")
     orcid_id = os.environ.get("ORCID_ID")
@@ -132,52 +133,94 @@ def get_orcid_token():
     return orcid_token
 
 
-def record_search(url, token, email):
+def record_search(url, email, interactive=False):
     """Given a url (with a name or email) do a record search looking for an orcid id
     """
-    response = requests.get(
-        url,
-        headers={"Authorization": "bearer %s" % token, "Accept": "application/json"},
-    )
+    response = requests.get(url, headers={"Accept": "application/json"})
     if response.status_code != 200:
         return
 
-    result = response.json().get("result", []) or []
+    results = response.json().get("expanded-result", []) or []
 
-    if not result:
+    if not results:
         return
 
     # We found only one matching result
-    if len(result) == 1:
-        return result[0]["orcid-identifier"]["path"]
+    if len(results) == 1:
+        return results[0]["orcid-id"]
+
+    # Only stream results to screen in interactive mode
+    if not interactive:
+        bot.info(
+            f"{email}: found more than 1 result, run with --interactive mode to select."
+        )
+        return
 
     # One or more results
-    ids = "\n".join([x["orcid-identifier"]["path"] for x in result])
-    bot.warning(
-        f"Found {len(result)} results for {email}:\n\n{ids}\n"
-        "You should look these up and add the correct in your .tributors lookup"
-    )
+    if len(results) > 10:
+        bot.warning(f"Found ,ore than 10 results found, will only show top 10.")
+
+    print("\n\n%s\n======================================================" % email)
+    for idx, r in enumerate(results):
+
+        # Limit is ten results, count starting at 0
+        idx = idx + 1
+        if idx > 10:
+            break
+
+        record = "  Name: %s, %s\n  Orcid: %s" % (
+            r["family-names"],
+            r["given-names"],
+            r["orcid-id"],
+        )
+        if r["institution-name"]:
+            record = "%s\n  Institutions: %s" % (
+                record,
+                ", ".join(r["institution-name"]),
+            )
+        if r["other-name"]:
+            record = "%s\n  Other Names: %s" % (record, ", ".join(r["other-name"]))
+        if r["email"]:
+            record = "%s\n  Email: %s" % (record, r["email"])
+        if not interactive:
+            print("%s\n" % record)
+        else:
+            print("[%s]\n%s\n" % (idx, record))
+
+    # If interactive, ask for choice prompt
+    if interactive:
+        choices = [str(i) for i, _ in enumerate(results)] + ["s", "S", "skip"]
+        prefix = "1:%s or s to skip" % ("10" if len(results) > 10 else len(results))
+        choice = choice_prompt(
+            "Please enter a choice, or s to skip.",
+            choices=choices,
+            choice_prefix=prefix,
+            multiple=False,
+        )
+
+        if not choice or choice in ["s", "S", "skip"]:
+            return
+
+        # Return the orcid identifier
+        return results[int(choice) - 1]["orcid-id"]
 
 
-def get_orcid(email, token, name=None):
-    """Given a GitHub repository address, retrieve a lookup of contributors
-       from the API endpoint. We look to use the GITHUB_TOKEN if exported
-       to the environment, and exit if the response has any issue
+def get_orcid(email, name=None, interactive=False):
+    """Get an orcid identifier for a given email or name.
     """
-    # We must have a token, and an email OR name
-    if not token and (not email and not name):
+    # We must have an email OR name
+    if not email and not name:
         return
 
     # First look for records based on email
     orcid_id = None
     if email:
-        url = "https://pub.orcid.org/v3.0/search/?q=email:%s" % email
-        orcid_id = record_search(url, token, email)
+        url = "https://pub.orcid.org/v3.0/expanded-search?q=email:%s" % email
+        orcid_id = record_search(url, email, interactive)
 
     # Attempt # 2 will use the first and last name
     if name is not None and not orcid_id:
 
-        # If no comma, likely a space delimiter
         delim = "," if "," in name else " "
         cleaner = "," if delim == " " else " "
 
@@ -190,30 +233,30 @@ def get_orcid(email, token, name=None):
 
         last, first = parts[0].strip(cleaner), " ".join(parts[1:]).strip(cleaner)
         url = (
-            "https://pub.orcid.org/v3.0/search/?q=given-names:%s+AND+family-name:%s"
+            "https://pub.orcid.org/v3.0/expanded-search?q=given-names:%s+AND+family-name:%s"
             % (first, last)
         )
-        orcid_id = record_search(url, token, name)
+        orcid_id = record_search(url, name, interactive)
 
         # Attempt # 3 will try removing the middle name
         if " " in first:
             url = (
-                "https://pub.orcid.org/v3.0/search/?q=given-names:%s+AND+family-name:%s"
+                "https://pub.orcid.org/v3.0/expanded-search?q=given-names:%s+AND+family-name:%s"
                 % (first.split(" ")[0].strip(), last)
             )
-            orcid_id = record_search(url, token, name)
+            orcid_id = record_search(url, name, interactive)
 
         # Attempt # 4 will reverse (some orcid entries are last, first, others the opposite
         if orcid_id is None:
             url = (
-                "https://pub.orcid.org/v3.0/search/?q=given-names:%s+AND+family-name:%s"
+                "https://pub.orcid.org/v3.0/expanded-search?q=given-names:%s+AND+family-name:%s"
                 % (last, first)
             )
-            orcid_id = record_search(url, token, name)
+            orcid_id = record_search(url, name, interactive)
 
         # Last attempt looks in "Other names"
         if orcid_id is None:
-            url = "https://pub.orcid.org/v3.0/search/?q=other-names:%s" % (name)
-            orcid_id = record_search(url, token, name)
+            url = "https://pub.orcid.org/v3.0/expanded-search?q=other-names:%s" % (name)
+            orcid_id = record_search(url, name, interactive)
 
     return orcid_id

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -242,7 +242,7 @@ def get_orcid(email, name=None, interactive=False):
 
         # Last attempt tries full name
         if orcid_id is None:
-            url = "https://pub.orcid.org/v3.0/expanded-search?q=%s" % (name)
+            url = "https://pub.orcid.org/v3.0/expanded-search?q=%s" % name
             orcid_id = record_search(url, name, interactive)
 
     return orcid_id

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -158,7 +158,7 @@ def record_search(url, email, interactive=False):
 
     # One or more results
     if len(results) > 10:
-        bot.warning(f"Found ,ore than 10 results found, will only show top 10.")
+        bot.warning("Found more than 10 results, will only show top 10.")
 
     print("\n\n%s\n======================================================" % email)
     for idx, r in enumerate(results):

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -230,7 +230,7 @@ def get_orcid(email, name=None, interactive=False):
 
         last, first = parts[0].strip(cleaner), " ".join(parts[1:]).strip(cleaner)
         url = (
-            "https://pub.orcid.org/v3.0/expanded-search?q=given-names:%s+AND+family-name:%s"
+            "https://pub.orcid.org/v3.0/expanded-search?q=%s+AND+%s"
             % (first, last)
         )
         orcid_id = record_search(url, name, interactive)
@@ -238,22 +238,14 @@ def get_orcid(email, name=None, interactive=False):
         # Attempt # 3 will try removing the middle name
         if " " in first:
             url = (
-                "https://pub.orcid.org/v3.0/expanded-search?q=given-names:%s+AND+family-name:%s"
+                "https://pub.orcid.org/v3.0/expanded-search?q=%s+AND+%s"
                 % (first.split(" ")[0].strip(), last)
             )
             orcid_id = record_search(url, name, interactive)
 
-        # Attempt # 4 will reverse (some orcid entries are last, first, others the opposite
+        # Last attempt tries full name
         if orcid_id is None:
-            url = (
-                "https://pub.orcid.org/v3.0/expanded-search?q=given-names:%s+AND+family-name:%s"
-                % (last, first)
-            )
-            orcid_id = record_search(url, name, interactive)
-
-        # Last attempt looks in "Other names"
-        if orcid_id is None:
-            url = "https://pub.orcid.org/v3.0/expanded-search?q=other-names:%s" % (name)
+            url = "https://pub.orcid.org/v3.0/expanded-search?q=%s" % (name)
             orcid_id = record_search(url, name, interactive)
 
     return orcid_id

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -229,17 +229,14 @@ def get_orcid(email, name=None, interactive=False):
             return orcid_id
 
         last, first = parts[0].strip(cleaner), " ".join(parts[1:]).strip(cleaner)
-        url = (
-            "https://pub.orcid.org/v3.0/expanded-search?q=%s+AND+%s"
-            % (first, last)
-        )
+        url = "https://pub.orcid.org/v3.0/expanded-search?q=%s+AND+%s" % (first, last)
         orcid_id = record_search(url, name, interactive)
 
         # Attempt # 3 will try removing the middle name
         if " " in first:
-            url = (
-                "https://pub.orcid.org/v3.0/expanded-search?q=%s+AND+%s"
-                % (first.split(" ")[0].strip(), last)
+            url = "https://pub.orcid.org/v3.0/expanded-search?q=%s+AND+%s" % (
+                first.split(" ")[0].strip(),
+                last,
             )
             orcid_id = record_search(url, name, interactive)
 

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -73,15 +73,12 @@ class OrcidIdentifier:
         )
 
     def get_record(self):
-        if not self.orcid or not self.token:
+        if not self.orcid:
             return
 
         response = requests.get(
             "https://pub.orcid.org/v2.1/%s/record" % self.orcid,
-            headers={
-                "Authorization": "bearer %s" % self.token,
-                "Accept": "application/json",
-            },
+            headers={"Accept": "application/json",},
         )
         if response.status_code != 200:
             return

--- a/tributors/main/orcid.py
+++ b/tributors/main/orcid.py
@@ -186,7 +186,7 @@ def get_orcid(email, token, name=None):
         # No go if only a first or last name
         if len(parts) == 1:
             bot.debug(f"Skipping {name}, first and last are required for search.")
-            break
+            return orcid_id
 
         last, first = parts[0].strip(cleaner), " ".join(parts[1:]).strip(cleaner)
         url = (

--- a/tributors/main/parsers/base.py
+++ b/tributors/main/parsers/base.py
@@ -33,7 +33,6 @@ class ParserBase:
         self.cache = {}
         self.contributors = {}
         self.thresh = 1
-        self.orcid_token = None
         self.params = params or {}
         self.data = {}
 
@@ -144,6 +143,8 @@ class ParserBase:
         """A shared function to run additional parsing on the cache, such
            as adding an orcid id when an email is defined. 
         """
+        interactive = self.params.get("--interactive", False)
+
         # If the parser can be used as a resource, use it to update .tributors
         if hasattr(self, "update_lookup") and update_lookup:
             self.update_lookup()
@@ -154,11 +155,11 @@ class ParserBase:
             # If we have an email, and orcid isn't defined
             if "orcid" not in entry:
                 orcid = get_orcid(
-                    entry.get("email"), self.orcid_token, entry.get("name")
+                    entry.get("email"), entry.get("name"), interactive=interactive
                 )
                 if orcid:
                     entry["orcid"] = orcid
-                    cli = OrcidIdentifier(orcid, self.orcid_token)
+                    cli = OrcidIdentifier(orcid)
 
                     # If we found the record, update metadata
                     if (

--- a/tributors/main/parsers/zenodo.py
+++ b/tributors/main/parsers/zenodo.py
@@ -113,6 +113,7 @@ class ZenodoParser(ParserBase):
         """Zenodo is a special case that has emails and real usernames, so we
            can parse through the existing file and look for orcid identifiers
         """
+        interactive = self.params.get("--interactive", False)
         creators = []
         for user in self.data.get("creators", []):
             orcid = user.get("orcid")
@@ -121,9 +122,9 @@ class ZenodoParser(ParserBase):
             if orcid is not None:
                 creators.append(user)
                 continue
-            if email or name and self.orcid_token is not None:
+            if email or name:
                 orcid = get_orcid(
-                    email=email, token=self.orcid_token, name=name.strip()
+                    email=email, name=name.strip(), interactive=interactive
                 )
                 if orcid:
                     user["orcid"] = orcid

--- a/tributors/utils/prompt.py
+++ b/tributors/utils/prompt.py
@@ -40,6 +40,8 @@ def choice_prompt(prompt, choices, choice_prefix=None, multiple=False):
     """
     choice = None
     print(prompt)
+
+    # Support for Python 2 (raw_input)
     get_input = getattr(__builtins__, "raw_input", input)
 
     if not choice_prefix:
@@ -54,5 +56,5 @@ def choice_prompt(prompt, choices, choice_prefix=None, multiple=False):
             contenders = choice.strip().split(" ")
             if all([x in choices for x in contenders]):
                 choices.append(choice)
-        message = "Please enter a valid option in [%s]" % (choice_prefix)
+        message = "Please enter a valid option in [%s]" % choice_prefix
     return choice

--- a/tributors/utils/prompt.py
+++ b/tributors/utils/prompt.py
@@ -52,7 +52,7 @@ def choice_prompt(prompt, choices, choice_prefix=None, multiple=False):
         # If multiple allowed, add selection to choices if includes all vaid
         if multiple is True:
             contenders = choice.strip().split(" ")
-            if all([x in choices for x in contenders]):
+            if all(x in choices for x in contenders):
                 choices.append(choice)
         message = "Please enter a valid option in [%s]" % (choice_prefix)
     return choice

--- a/tributors/utils/prompt.py
+++ b/tributors/utils/prompt.py
@@ -27,3 +27,32 @@ def request_input():
             lines.append(line)
 
     return "\n".join(lines)
+
+
+def choice_prompt(prompt, choices, choice_prefix=None, multiple=False):
+    """Ask the user for a prompt, and only return when one of the requested
+       options is provided.
+       Parameters
+       ==========
+       prompt: the prompt to ask the user
+       choices: a list of choices that are valid.   
+       multiple: allow multiple responses (separated by spaces)
+    """
+    choice = None
+    print(prompt)
+    get_input = getattr(__builtins__, "raw_input", input)
+
+    if not choice_prefix:
+        choice_prefix = "/".join(choices)
+    message = "[%s] : " % (choice_prefix)
+
+    while choice not in choices:
+        choice = get_input(message).strip()
+
+        # If multiple allowed, add selection to choices if includes all vaid
+        if multiple is True:
+            contenders = choice.strip().split(" ")
+            if all([x in choices for x in contenders]):
+                choices.append(choice)
+        message = "Please enter a valid option in [%s]" % (choice_prefix)
+    return choice

--- a/tributors/version.py
+++ b/tributors/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.18"
+__version__ = "0.0.19"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "tributors"


### PR DESCRIPTION
This pull request will do the following:
 - fix #46 adding "other-names" as final search
 - fix #47 not allowing any search without a first or last name.
 - close #41 because we don't need an orcid id anymore :tada: 

This means that with this verison, you should be able to run with interactive mode:

```bash
$ tributors update zenodo --interactive
```

Signed-off-by: vsoch <vsochat@stanford.edu>