### PR TITLE
adding support to run twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/con/tributors/tree/master) (0.0.x)
+ - add ability to run twice to action (0.0.21)
  - searching orcid for other-names as final resort, requiring first/last (0.0.19)
  - searching for last, first and reverse for orcid lookup (0.0.18)
  - unicode characters allowed, and dont update users with orcids (0.0.17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/con/tributors/tree/master) (0.0.x)
- - add ability to run twice to action (0.0.21)
+ - add to action ability to run command twice (0.0.21)
  - searching orcid for other-names as final resort, requiring first/last (0.0.19)
  - searching for last, first and reverse for orcid lookup (0.0.18)
  - unicode characters allowed, and dont update users with orcids (0.0.17)

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,9 @@ inputs:
   allcontrib_skip_generate:
     description: "skip running all-contributors generate"
     default: false
+  run_twice:
+    description: "run twice to avoid opening two pull requests"
+    default: false
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,8 @@ inputs:
     description: "skip running all-contributors generate"
     default: false
   run_twice:
-    description: "run twice to avoid opening two pull requests"
-    default: false
+    description: "run twice to avoid opening two pull requests (defaults to true)"
+    default: true
 
 runs:
   using: docker

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -94,7 +94,7 @@ echo $COMMAND
 $COMMAND
 
 # Run twice to get additional metadata
-if [ "${INPUT_RUN_TWICE}" == "true" ]; then
+if [ "${INPUT_RUN_TWICE:-true}" == "true" ]; then
     printf "Running twice to get additional updates...\n"
     $COMMAND
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -89,7 +89,15 @@ if [ "${RUN_CODEMETA}" == "true" ]; then
 fi
 
 echo $COMMAND
+
+# First time might just create content
 $COMMAND
+
+# Run twice to get additional metadata
+if [ "${INPUT_RUN_TWICE}" == "true" ]; then
+    printf "Running twice to get additional updates...\n"
+    $COMMAND
+fi
 
 # Finally, run all-contributors generate
 if [ "${INPUT_ALLCONTRIB_SKIP_GENERATE}" == "false" ]; then

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -629,6 +629,7 @@ dashes.
 | codemeta_file | the codemeta file to update, if defined | false | codemeta.json |
 | mailmap_file | the mailmap file to use for update-lookup, if needed | false | .mailmap |
 | update_lookup | one or more resources to use to update the .tributors file before running update | false | unset |
+| run_twice | if you find the action opens two PRs, run the command twice so new folks are added and then metadata updated | false | false |
 
 If you define `update_lookup`, you should list the (space separated) names of the parsers that you want to use. For example:
 
@@ -636,7 +637,38 @@ If you define `update_lookup`, you should list the (space separated) names of th
    update_lookup: mailmap zenodo
 ```
 
-The same file names (e.g., *_file) will be used.
+The same file names (e.g., *_file) will be used. Here is an example to update contributors, asking to run twice.
+
+```yaml
+name: allcontributors-auto-detect
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Update:
+    name: Generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Tributors Update      
+        uses: con/tributors@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:        
+          parsers: unset
+          update_lookup: github
+          log_level: DEBUG
+          force: true
+          threshold: 1
+          run_twice: true
+```
+
+The above would be followed by a pull request action (e.g., commit and push to main branch
+or open a pull request).
 
 
 If you aren't familiar with all-contributors, you'll need to add some

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -629,7 +629,7 @@ dashes.
 | codemeta_file | the codemeta file to update, if defined | false | codemeta.json |
 | mailmap_file | the mailmap file to use for update-lookup, if needed | false | .mailmap |
 | update_lookup | one or more resources to use to update the .tributors file before running update | false | unset |
-| run_twice | if you find the action opens two PRs, run the command twice so new folks are added and then metadata updated | false | false |
+| run_twice | if you find the action opens two PRs, run the command twice so new folks are added and then metadata updated | false | true |
 
 If you define `update_lookup`, you should list the (space separated) names of the parsers that you want to use. For example:
 
@@ -637,7 +637,7 @@ If you define `update_lookup`, you should list the (space separated) names of th
    update_lookup: mailmap zenodo
 ```
 
-The same file names (e.g., *_file) will be used. Here is an example to update contributors, asking to run twice.
+The same file names (e.g., *_file) will be used. Here is an example to update contributors, asking to not run twice.
 
 ```yaml
 name: allcontributors-auto-detect
@@ -664,7 +664,7 @@ jobs:
           log_level: DEBUG
           force: true
           threshold: 1
-          run_twice: true
+          run_twice: false
 ```
 
 The above would be followed by a pull request action (e.g., commit and push to main branch

--- a/tributors/version.py
+++ b/tributors/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "tributors"


### PR DESCRIPTION
Sometimes we add a new contributor on a run, and once we have basic metadata a second PR is opened shortly after with this additional metadata (that we could not look up before because we did not have them recorded). This change will add a new
variable run_twice to the action to allow the user to run the workflow twice instead of once to reduce the updates to one PR.

I will test the branch on one of my projects where I'm expecting contributors to be found, and it would need to be run twice!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>