### PR TITLE
Boost vsoch/pull-request-action to 1.0.24

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -76,7 +76,7 @@ jobs:
           echo "PULL_REQUEST_BODY=Tributors update automated pull request." >> $GITHUB_ENV
 
       - name: Open Pull Request
-        uses: vsoch/pull-request-action@1.0.6
+        uses: vsoch/pull-request-action@1.0.24
         if: ${{ env.OPEN_PULL_REQUEST == '1' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
 since 1.0.6 was removed for some reason, caused an error in https://github.com/con/tributors/actions/runs/5195375035/jobs/9368029762