### PR TITLE
fix link to Contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![docs/assets/img/logo.png](https://raw.githubusercontent.com/con/tributors/master/docs/assets/img/logo.png)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [Documentation](https://con.github.io/tributors/)


### PR DESCRIPTION
Minor fix: the link included on the "all contributors" badge has a trailing "-" character that prevents navigating to the correct section.

I noticed this in a dependent repository, and naively tried to fix it there:
https://github.com/USRSE/usrse.github.io/pull/1190
before realizing that it gets regenerated by the workflow:
https://github.com/USRSE/usrse.github.io/pull/1191